### PR TITLE
Support module: One Page Checkout PS - PresTeamShop - v4.1.1 (Prestashop >= 1.7.6.X)

### DIFF
--- a/src/hipay_enterprise/hipay_enterprise-17.php
+++ b/src/hipay_enterprise/hipay_enterprise-17.php
@@ -233,6 +233,7 @@ class HipayEnterpriseNew extends Hipay_enterprise
                             'is_guest' => $this->customer->is_guest,
                             'customerFirstName' => $this->customer->firstname,
                             'customerLastName' => $this->customer->lastname,
+                            'LanguagueIsoCode' => $this->context->language->iso_code,
                         ]
                     );
 

--- a/src/hipay_enterprise/views/js/card-js.min.js
+++ b/src/hipay_enterprise/views/js/card-js.min.js
@@ -10,729 +10,746 @@
  * @license   https://github.com/hipay/hipay-enterprise-sdk-prestashop/blob/master/LICENSE.md
  */
 // jQuery.noConflict();
-function CardJs(t) {
-  (this.elem = jQuery(t)),
-    (this.captureName =
-      !!this.elem.data("capture-name") && this.elem.data("capture-name")),
-    (this.iconColour =
-      !!this.elem.data("icon-colour") && this.elem.data("icon-colour")),
-    (this.stripe = !!this.elem.data("stripe") && this.elem.data("stripe")),
-    this.stripe && (this.captureName = !1),
-    this.initCardNumberInput(),
-    this.initNameInput(),
-    this.initExpiryMonthInput(),
-    this.initExpiryYearInput(),
-    this.initCvcInput(),
-    this.elem.empty(),
-    this.setupCardNumberInput(),
-    this.setupNameInput(),
-    this.setupExpiryInput(),
-    this.setupCvcInput(),
-    this.iconColour && this.setIconColour(this.iconColour),
-    this.refreshCreditCardTypeIcon();
-}
-(CardJs.prototype.constructor = CardJs),
-  (CardJs.KEYS = {
-    0: 48,
-    9: 57,
-    NUMPAD_0: 96,
-    NUMPAD_9: 105,
-    DELETE: 46,
-    BACKSPACE: 8,
-    ARROW_LEFT: 37,
-    ARROW_RIGHT: 39,
-    ARROW_UP: 38,
-    ARROW_DOWN: 40,
-    HOME: 36,
-    END: 35,
-    TAB: 9,
-    A: 65,
-    X: 88,
-    C: 67,
-    V: 86
-  }),
-  (CardJs.CREDIT_CARD_NUMBER_DEFAULT_MASK = "XXXXXXXXXXXXXXXXXXXXXXXXX"),
-  (CardJs.CREDIT_CARD_NUMBER_VISA_MASK = "XXXX XXXX XXXX XXXX"),
-  (CardJs.CREDIT_CARD_NUMBER_MASTERCARD_MASK = "XXXX XXXX XXXX XXXX"),
-  (CardJs.CREDIT_CARD_NUMBER_MAESTRO_MASK = "XXXX XXXX XXXX XXXX XXX"),
-  (CardJs.CREDIT_CARD_NUMBER_BCMC_MASK = "XXXX XXXX XXXX XXXXX XXX"),
-  (CardJs.CREDIT_CARD_NUMBER_DISCOVER_MASK = "XXXX XXXX XXXX XXXX"),
-  (CardJs.CREDIT_CARD_NUMBER_JCB_MASK = "XXXX XXXX XXXX XXXX"),
-  (CardJs.CREDIT_CARD_NUMBER_AMEX_MASK = "XXXX XXXXXX XXXXX"),
-  (CardJs.CREDIT_CARD_NUMBER_DINERS_MASK = "XXXX XXXX XXXX XX"),
-  (CardJs.prototype.creditCardNumberMask =
-    CardJs.CREDIT_CARD_NUMBER_DEFAULT_MASK),
-  (CardJs.CREDIT_CARD_NUMBER_PLACEHOLDER = i18nCardNumber),
-  (CardJs.NAME_PLACEHOLDER = i18nNameOnCard),
-  (CardJs.EXPIRY_MASK = "XX / XX"),
-  (CardJs.EXPIRY_PLACEHOLDER = i18nDate),
-  (CardJs.EXPIRY_USE_DROPDOWNS = 1),
-  (CardJs.EXPIRY_NUMBER_OF_YEARS = 10),
-  (CardJs.CVC_MASK_3 = "XXX"),
-  (CardJs.CVC_MASK_4 = "XXXX"),
-  (CardJs.CVC_PLACEHOLDER = i18nCVC),
-  (CardJs.CREDIT_CARD_SVG =
-    '<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="3px" width="24px" height="17px" viewBox="0 0 216 146" enable-background="new 0 0 216 146" xml:space="preserve"><g><path class="svg" d="M182.385,14.258c-2.553-2.553-5.621-3.829-9.205-3.829H42.821c-3.585,0-6.653,1.276-9.207,3.829c-2.553,2.553-3.829,5.621-3.829,9.206v99.071c0,3.585,1.276,6.654,3.829,9.207c2.554,2.553,5.622,3.829,9.207,3.829H173.18c3.584,0,6.652-1.276,9.205-3.829s3.83-5.622,3.83-9.207V23.464C186.215,19.879,184.938,16.811,182.385,14.258z M175.785,122.536c0,0.707-0.258,1.317-0.773,1.834c-0.516,0.515-1.127,0.772-1.832,0.772H42.821c-0.706,0-1.317-0.258-1.833-0.773c-0.516-0.518-0.774-1.127-0.774-1.834V73h135.571V122.536z M175.785,41.713H40.214v-18.25c0-0.706,0.257-1.316,0.774-1.833c0.516-0.515,1.127-0.773,1.833-0.773H173.18c0.705,0,1.316,0.257,1.832,0.773c0.516,0.517,0.773,1.127,0.773,1.833V41.713z"/><rect class="svg" x="50.643" y="104.285" width="20.857" height="10.429"/><rect class="svg" x="81.929" y="104.285" width="31.286" height="10.429"/></g></svg>'),
-  (CardJs.LOCK_SVG =
-    '<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="3px" width="24px" height="17px" viewBox="0 0 216 146" enable-background="new 0 0 216 146" xml:space="preserve"><path class="svg" d="M152.646,70.067c-1.521-1.521-3.367-2.281-5.541-2.281H144.5V52.142c0-9.994-3.585-18.575-10.754-25.745c-7.17-7.17-15.751-10.755-25.746-10.755s-18.577,3.585-25.746,10.755C75.084,33.567,71.5,42.148,71.5,52.142v15.644h-2.607c-2.172,0-4.019,0.76-5.54,2.281c-1.521,1.52-2.281,3.367-2.281,5.541v46.929c0,2.172,0.76,4.019,2.281,5.54c1.521,1.52,3.368,2.281,5.54,2.281h78.214c2.174,0,4.02-0.76,5.541-2.281c1.52-1.521,2.281-3.368,2.281-5.54V75.607C154.93,73.435,154.168,71.588,152.646,70.067z M128.857,67.786H87.143V52.142c0-5.757,2.037-10.673,6.111-14.746c4.074-4.074,8.989-6.11,14.747-6.11s10.673,2.036,14.746,6.11c4.073,4.073,6.11,8.989,6.11,14.746V67.786z"/></svg>'),
-  (CardJs.CALENDAR_SVG =
-    '<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="4px" width="24px" height="16px" viewBox="0 0 216 146" enable-background="new 0 0 216 146" xml:space="preserve"><path class="svg" d="M172.691,23.953c-2.062-2.064-4.508-3.096-7.332-3.096h-10.428v-7.822c0-3.584-1.277-6.653-3.83-9.206c-2.554-2.553-5.621-3.83-9.207-3.83h-5.213c-3.586,0-6.654,1.277-9.207,3.83c-2.554,2.553-3.83,5.622-3.83,9.206v7.822H92.359v-7.822c0-3.584-1.277-6.653-3.83-9.206c-2.553-2.553-5.622-3.83-9.207-3.83h-5.214c-3.585,0-6.654,1.277-9.207,3.83c-2.553,2.553-3.83,5.622-3.83,9.206v7.822H50.643c-2.825,0-5.269,1.032-7.333,3.096s-3.096,4.509-3.096,7.333v104.287c0,2.823,1.032,5.267,3.096,7.332c2.064,2.064,4.508,3.096,7.333,3.096h114.714c2.824,0,5.27-1.032,7.332-3.096c2.064-2.064,3.096-4.509,3.096-7.332V31.286C175.785,28.461,174.754,26.017,172.691,23.953z M134.073,13.036c0-0.761,0.243-1.386,0.731-1.874c0.488-0.488,1.113-0.733,1.875-0.733h5.213c0.762,0,1.385,0.244,1.875,0.733c0.488,0.489,0.732,1.114,0.732,1.874V36.5c0,0.761-0.244,1.385-0.732,1.874c-0.49,0.488-1.113,0.733-1.875,0.733h-5.213c-0.762,0-1.387-0.244-1.875-0.733s-0.731-1.113-0.731-1.874V13.036z M71.501,13.036c0-0.761,0.244-1.386,0.733-1.874c0.489-0.488,1.113-0.733,1.874-0.733h5.214c0.761,0,1.386,0.244,1.874,0.733c0.488,0.489,0.733,1.114,0.733,1.874V36.5c0,0.761-0.244,1.386-0.733,1.874c-0.489,0.488-1.113,0.733-1.874,0.733h-5.214c-0.761,0-1.386-0.244-1.874-0.733c-0.488-0.489-0.733-1.113-0.733-1.874V13.036z M165.357,135.572H50.643V52.143h114.714V135.572z"/></svg>'),
-  (CardJs.USER_SVG =
-    '<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="4px" width="24px" height="16px" viewBox="0 0 216 146" enable-background="new 0 0 216 146" xml:space="preserve"><g><path class="svg" d="M107.999,73c8.638,0,16.011-3.056,22.12-9.166c6.111-6.11,9.166-13.483,9.166-22.12c0-8.636-3.055-16.009-9.166-22.12c-6.11-6.11-13.484-9.165-22.12-9.165c-8.636,0-16.01,3.055-22.12,9.165c-6.111,6.111-9.166,13.484-9.166,22.12c0,8.637,3.055,16.01,9.166,22.12C91.99,69.944,99.363,73,107.999,73z"/><path class="svg" d="M165.07,106.037c-0.191-2.743-0.571-5.703-1.141-8.881c-0.57-3.178-1.291-6.124-2.16-8.84c-0.869-2.715-2.037-5.363-3.504-7.943c-1.466-2.58-3.15-4.78-5.052-6.6s-4.223-3.272-6.965-4.358c-2.744-1.086-5.772-1.63-9.085-1.63c-0.489,0-1.63,0.584-3.422,1.752s-3.815,2.472-6.069,3.911c-2.254,1.438-5.188,2.743-8.799,3.909c-3.612,1.168-7.237,1.752-10.877,1.752c-3.639,0-7.264-0.584-10.876-1.752c-3.611-1.166-6.545-2.471-8.799-3.909c-2.254-1.439-4.277-2.743-6.069-3.911c-1.793-1.168-2.933-1.752-3.422-1.752c-3.313,0-6.341,0.544-9.084,1.63s-5.065,2.539-6.966,4.358c-1.901,1.82-3.585,4.02-5.051,6.6s-2.634,5.229-3.503,7.943c-0.869,2.716-1.589,5.662-2.159,8.84c-0.571,3.178-0.951,6.137-1.141,8.881c-0.19,2.744-0.285,5.554-0.285,8.433c0,6.517,1.983,11.664,5.948,15.439c3.965,3.774,9.234,5.661,15.806,5.661h71.208c6.572,0,11.84-1.887,15.806-5.661c3.966-3.775,5.948-8.921,5.948-15.439C165.357,111.591,165.262,108.78,165.07,106.037z"/></g></svg>'),
-  (CardJs.MAIL_SVG =
-    '<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"x="0px" y="4px" width="24px" height="16px" viewBox="0 0 216 146" enable-background="new 0 0 216 146" xml:space="preserve"><path class="svg" d="M177.171,19.472c-2.553-2.553-5.622-3.829-9.206-3.829H48.036c-3.585,0-6.654,1.276-9.207,3.829C36.276,22.025,35,25.094,35,28.679v88.644c0,3.585,1.276,6.652,3.829,9.205c2.553,2.555,5.622,3.83,9.207,3.83h119.929c3.584,0,6.653-1.275,9.206-3.83c2.554-2.553,3.829-5.621,3.829-9.205V28.679C181,25.094,179.725,22.025,177.171,19.472zM170.57,117.321c0,0.706-0.258,1.317-0.774,1.833s-1.127,0.773-1.832,0.773H48.035c-0.706,0-1.317-0.257-1.833-0.773c-0.516-0.516-0.774-1.127-0.774-1.833V54.75c1.738,1.955,3.612,3.748,5.622,5.377c14.557,11.189,26.126,20.368,34.708,27.538c2.77,2.336,5.024,4.155,6.762,5.459s4.087,2.62,7.047,3.951s5.744,1.995,8.351,1.995H108h0.081c2.606,0,5.392-0.664,8.351-1.995c2.961-1.331,5.311-2.647,7.049-3.951c1.737-1.304,3.992-3.123,6.762-5.459c8.582-7.17,20.15-16.349,34.707-27.538c2.01-1.629,3.885-3.422,5.621-5.377V117.321z M170.57,30.797v0.896c0,3.204-1.262,6.776-3.787,10.713c-2.525,3.938-5.256,7.075-8.188,9.41c-10.484,8.257-21.373,16.865-32.672,25.827c-0.326,0.271-1.277,1.073-2.852,2.403c-1.574,1.331-2.824,2.351-3.748,3.056c-0.924,0.707-2.131,1.562-3.625,2.566s-2.865,1.752-4.114,2.24s-2.417,0.732-3.503,0.732H108h-0.082c-1.086,0-2.253-0.244-3.503-0.732c-1.249-0.488-2.621-1.236-4.114-2.24c-1.493-1.004-2.702-1.859-3.625-2.566c-0.923-0.705-2.173-1.725-3.748-3.056c-1.575-1.33-2.526-2.132-2.852-2.403c-11.297-8.962-22.187-17.57-32.67-25.827c-7.985-6.3-11.977-14.013-11.977-23.138c0-0.706,0.258-1.317,0.774-1.833c0.516-0.516,1.127-0.774,1.833-0.774h119.929c0.434,0.244,0.814,0.312,1.141,0.204c0.326-0.11,0.57,0.094,0.732,0.61c0.163,0.516,0.312,0.76,0.448,0.733c0.136-0.027,0.218,0.312,0.245,1.019c0.025,0.706,0.039,1.061,0.039,1.061V30.797z"/></svg>'),
-  (CardJs.INFORMATION_SVG =
-    '<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="4px" width="24px" height="16px" viewBox="0 0 216 146" enable-background="new 0 0 216 146" xml:space="preserve"><g><path class="svg" d="M97.571,41.714h20.859c1.411,0,2.633-0.516,3.666-1.548c1.031-1.031,1.547-2.254,1.547-3.666V20.857c0-1.412-0.516-2.634-1.549-3.667c-1.031-1.031-2.254-1.548-3.666-1.548H97.571c-1.412,0-2.634,0.517-3.666,1.548c-1.032,1.032-1.548,2.255-1.548,3.667V36.5c0,1.412,0.516,2.635,1.548,3.666C94.937,41.198,96.159,41.714,97.571,41.714z"/><path class="svg" d="M132.523,111.048c-1.031-1.032-2.254-1.548-3.666-1.548h-5.215V62.571c0-1.412-0.516-2.634-1.547-3.666c-1.033-1.032-2.255-1.548-3.666-1.548H87.143c-1.412,0-2.634,0.516-3.666,1.548c-1.032,1.032-1.548,2.254-1.548,3.666V73c0,1.412,0.516,2.635,1.548,3.666c1.032,1.032,2.254,1.548,3.666,1.548h5.215V109.5h-5.215c-1.412,0-2.634,0.516-3.666,1.548c-1.032,1.032-1.548,2.254-1.548,3.666v10.429c0,1.412,0.516,2.635,1.548,3.668c1.032,1.03,2.254,1.547,3.666,1.547h41.714c1.412,0,2.634-0.517,3.666-1.547c1.031-1.033,1.547-2.256,1.547-3.668v-10.429C134.07,113.302,133.557,112.08,132.523,111.048z"/></g></svg>'),
-  (CardJs.keyCodeFromEvent = function (t) {
-    return t.which || t.keyCode;
-  }),
-  (CardJs.keyIsCommandFromEvent = function (t) {
-    return t.ctrlKey || t.metaKey;
-  }),
-  (CardJs.keyIsNumber = function (t) {
-    return CardJs.keyIsTopNumber(t) || CardJs.keyIsKeypadNumber(t);
-  }),
-  (CardJs.keyIsTopNumber = function (t) {
-    var e = CardJs.keyCodeFromEvent(t);
-    return e >= CardJs.KEYS[0] && e <= CardJs.KEYS[9];
-  }),
-  (CardJs.keyIsKeypadNumber = function (t) {
-    var e = CardJs.keyCodeFromEvent(t);
-    return e >= CardJs.KEYS.NUMPAD_0 && e <= CardJs.KEYS.NUMPAD_9;
-  }),
-  (CardJs.keyIsDelete = function (t) {
-    return CardJs.keyCodeFromEvent(t) == CardJs.KEYS.DELETE;
-  }),
-  (CardJs.keyIsBackspace = function (t) {
-    return CardJs.keyCodeFromEvent(t) == CardJs.KEYS.BACKSPACE;
-  }),
-  (CardJs.keyIsDeletion = function (t) {
-    return CardJs.keyIsDelete(t) || CardJs.keyIsBackspace(t);
-  }),
-  (CardJs.keyIsArrow = function (t) {
-    var e = CardJs.keyCodeFromEvent(t);
-    return e >= CardJs.KEYS.ARROW_LEFT && e <= CardJs.KEYS.ARROW_DOWN;
-  }),
-  (CardJs.keyIsNavigation = function (t) {
-    var e = CardJs.keyCodeFromEvent(t);
-    return e == CardJs.KEYS.HOME || e == CardJs.KEYS.END;
-  }),
-  (CardJs.keyIsKeyboardCommand = function (t) {
-    var e = CardJs.keyCodeFromEvent(t);
-    return (
-      CardJs.keyIsCommandFromEvent(t) &&
-      (e == CardJs.KEYS.A ||
-        e == CardJs.KEYS.X ||
-        e == CardJs.KEYS.C ||
-        e == CardJs.KEYS.V)
-    );
-  }),
-  (CardJs.keyIsTab = function (t) {
-    return CardJs.keyCodeFromEvent(t) == CardJs.KEYS.TAB;
-  }),
-  (CardJs.copyAllElementAttributes = function (t, e) {
-    $.each(t[0].attributes, function (t, r) {
-      e.attr(r.nodeName, r.nodeValue);
-    });
-  }),
-  (CardJs.numbersOnlyString = function (t) {
-    for (var e = "", r = 0; r < t.length; r++) {
-      var a = t.charAt(r);
-      !isNaN(parseInt(a)) && (e += a);
-    }
-    return e;
-  }),
-  (CardJs.applyFormatMask = function (t, e) {
-    for (var r = "", a = 0, s = 0; s < e.length; s++) {
-      var n = e[s];
-      if ("X" == n) {
-        if (!t.charAt(a)) break;
-        (r += t.charAt(a)), a++;
-      } else r += n;
-    }
-    return r;
-  }),
-  (CardJs.cardTypeFromNumber = function (t) {
-    if (((e = new RegExp("^30[0-5]")), null != t.match(e)))
-      return "Diners - Carte Blanche";
-    if (((e = new RegExp("^(30[6-9]|36|38)")), null != t.match(e)))
-      return "Diners";
-    if (((e = new RegExp("^35(2[89]|[3-8][0-9])")), null != t.match(e)))
-      return "JCB";
-    if (((e = new RegExp("^3[47]")), null != t.match(e))) return "AMEX";
-    if (
-      ((e = new RegExp("^(4026|417500|4508|4844|491(3|7))")),
-      null != t.match(e))
-    )
-      return "Visa Electron";
-    var e = new RegExp("^4");
-    return null != t.match(e)
-      ? "Visa"
-      : ((e = new RegExp(
-          "^(?:5[1-5][0-9]{2}|222[1-9]|22[3-9][0-9]|2[3-6][0-9]{2}|27[01][0-9]|2720)"
-        )),
-        null != t.match(e)
-          ? "Mastercard"
-          : ((e = new RegExp(
-              "^(6011|622(12[6-9]|1[3-9][0-9]|[2-8][0-9]{2}|9[0-1][0-9]|92[0-5]|64[4-9])|65)"
-            )),
-            null != t.match(e)
-              ? "Discover"
-              : ((e = new RegExp("^(6703)")),
-                null != t.match(e)
-                  ? "Bcmc"
-                  : ((e = new RegExp("^(5[0678]\\d\\d|6304|6390|67\\d\\d)")),
-                    null != t.match(e) ? "Maestro" : ""))));
-  }),
-  (CardJs.caretStartPosition = function (t) {
-    return "number" == typeof t.selectionStart && t.selectionStart;
-  }),
-  (CardJs.caretEndPosition = function (t) {
-    return "number" == typeof t.selectionEnd && t.selectionEnd;
-  }),
-  (CardJs.setCaretPosition = function (t, e) {
-    if (null != t)
-      if (t.createTextRange) {
-        var r = t.createTextRange();
-        r.move("character", e), r.select();
-      } else
-        t.selectionStart ? (t.focus(), t.setSelectionRange(e, e)) : t.focus();
-  }),
-  (CardJs.normaliseCaretPosition = function (t, e) {
-    var r = 0;
-    if (e < 0 || e > t.length) return 0;
-    for (var a = 0; a < t.length; a++) {
-      if (a == e) return r;
-      "X" == t[a] && r++;
-    }
-    return r;
-  }),
-  (CardJs.denormaliseCaretPosition = function (t, e) {
-    var r = 0;
-    if (e < 0 || e > t.length) return 0;
-    for (var a = 0; a < t.length; a++) {
-      if (r == e) return a;
-      "X" == t[a] && r++;
-    }
-    return t.length;
-  }),
-  (CardJs.filterNumberOnlyKey = function (t) {
-    var e = CardJs.keyIsNumber(t),
-      r = CardJs.keyIsDeletion(t),
-      a = CardJs.keyIsArrow(t),
-      s = CardJs.keyIsNavigation(t),
-      n = CardJs.keyIsKeyboardCommand(t),
-      i = CardJs.keyIsTab(t);
-    e || r || a || s || n || i || t.preventDefault();
-  }),
-  (CardJs.digitFromKeyCode = function (t) {
-    return t >= CardJs.KEYS[0] && t <= CardJs.KEYS[9]
-      ? t - CardJs.KEYS[0]
-      : t >= CardJs.KEYS.NUMPAD_0 && t <= CardJs.KEYS.NUMPAD_9
-      ? t - CardJs.KEYS.NUMPAD_0
-      : null;
-  }),
-  (CardJs.handleMaskedNumberInputKey = function (t, e) {
-    CardJs.filterNumberOnlyKey(t);
-    var r = t.which || t.keyCode,
-      a = t.target,
-      s = CardJs.caretStartPosition(a),
-      n = CardJs.caretEndPosition(a),
-      i = CardJs.normaliseCaretPosition(e, s),
-      p = CardJs.normaliseCaretPosition(e, n),
-      c = s,
-      o = CardJs.keyIsNumber(t),
-      d = CardJs.keyIsDelete(t),
-      u = CardJs.keyIsBackspace(t);
-    if (o || d || u) {
-      t.preventDefault();
-      var C = $(a).val(),
-        h = CardJs.numbersOnlyString(C),
-        l = CardJs.digitFromKeyCode(r),
-        y = p > i;
-      y && (h = h.slice(0, i) + h.slice(p)),
-        s != e.length &&
-          (o &&
-            C.length <= e.length &&
-            ((h = h.slice(0, i) + l + h.slice(i)),
-            (c = Math.max(
-              CardJs.denormaliseCaretPosition(e, i + 1),
-              CardJs.denormaliseCaretPosition(e, i + 2) - 1
-            ))),
-          d && (h = h.slice(0, i) + h.slice(i + 1))),
-        0 != s &&
-          u &&
-          !y &&
-          ((h = h.slice(0, i - 1) + h.slice(i)),
-          (c = CardJs.denormaliseCaretPosition(e, i - 1))),
-        $(a).val(CardJs.applyFormatMask(h, e)),
-        CardJs.setCaretPosition(a, c);
-    }
-  }),
-  (CardJs.handleCreditCardNumberKey = function (t, e) {
-    CardJs.handleMaskedNumberInputKey(t, e);
-  }),
-  (CardJs.handleCreditCardNumberChange = function (t) {}),
-  (CardJs.handleExpiryKey = function (t) {
-    CardJs.handleMaskedNumberInputKey(t, CardJs.EXPIRY_MASK);
-  }),
-  (CardJs.prototype.getCardNumber = function () {
-    return this.cardNumberInput.val();
-  }),
-  (CardJs.prototype.getCardType = function () {
-    return CardJs.cardTypeFromNumber(this.getCardNumber());
-  }),
-  (CardJs.prototype.getName = function () {
-    return this.nameInput.val();
-  }),
-  (CardJs.prototype.getExpiryMonth = function () {
-    return this.expiryMonthInput.val();
-  }),
-  (CardJs.prototype.getExpiryYear = function () {
-    return this.expiryYearInput.val();
-  }),
-  (CardJs.prototype.getCvc = function () {
-    return this.cvcInput.val();
-  }),
-  (CardJs.prototype.setIconColour = function (t) {
-    this.elem.find(".icon .svg").css({ fill: t });
-  }),
-  (CardJs.prototype.setIconColour = function (t) {
-    this.elem.find(".icon .svg").css({ fill: t });
-  }),
-  (CardJs.prototype.refreshCreditCardTypeIcon = function () {
-    this.setCardTypeIconFromNumber(
-      CardJs.numbersOnlyString(this.cardNumberInput.val())
-    );
-  }),
-  (CardJs.prototype.refreshCreditCardNumberFormat = function () {
-    var t = CardJs.numbersOnlyString($(this.cardNumberInput).val()),
-      e = CardJs.applyFormatMask(t, this.creditCardNumberMask);
-    $(this.cardNumberInput).val(e);
-  }),
-  (CardJs.prototype.refreshExpiryMonthYearInput = function () {
-    var t = CardJs.numbersOnlyString($(this.expiryMonthYearInput).val()),
-      e = CardJs.applyFormatMask(t, CardJs.EXPIRY_MASK);
-    $(this.expiryMonthYearInput).val(e);
-  }),
-  (CardJs.prototype.refreshCvc = function () {
-    var t = CardJs.numbersOnlyString($(this.cvcInput).val()),
-      e = CardJs.applyFormatMask(t, this.creditCardNumberMask);
-    $(this.cvcInput).val(e);
-  }),
-  (CardJs.prototype.clearCardTypeIcon = function () {
-    this.elem.find(".card-number-wrapper .card-type-icon").removeClass("show");
-  }),
-  (CardJs.prototype.setCardTypeIconAsVisa = function () {
-    this.elem
-      .find(".card-number-wrapper .card-type-icon")
-      .attr("class", "card-type-icon show visa");
-  }),
-  (CardJs.prototype.setCardTypeIconAsMasterCard = function () {
-    this.elem
-      .find(".card-number-wrapper .card-type-icon")
-      .attr("class", "card-type-icon show master-card");
-  }),
-  (CardJs.prototype.setCardTypeIconAsMaestro = function () {
-    this.elem
-      .find(".card-number-wrapper .card-type-icon")
-      .attr("class", "card-type-icon show maestro");
-  }),
-  (CardJs.prototype.setCardTypeIconAsBcmc = function () {
-    this.elem
-      .find(".card-number-wrapper .card-type-icon")
-      .attr("class", "card-type-icon show bcmc");
-  }),
-  (CardJs.prototype.setCardTypeIconAsAmericanExpress = function () {
-    this.elem
-      .find(".card-number-wrapper .card-type-icon")
-      .attr("class", "card-type-icon show american-express");
-  }),
-  (CardJs.prototype.setCardTypeIconAsDiscover = function () {
-    this.elem
-      .find(".card-number-wrapper .card-type-icon")
-      .attr("class", "card-type-icon show discover");
-  }),
-  (CardJs.prototype.setCardTypeIconAsDiners = function () {
-    this.elem
-      .find(".card-number-wrapper .card-type-icon")
-      .attr("class", "card-type-icon show diners");
-  }),
-  (CardJs.prototype.setCardTypeIconAsJcb = function () {
-    this.elem
-      .find(".card-number-wrapper .card-type-icon")
-      .attr("class", "card-type-icon show jcb");
-  }),
-  (CardJs.prototype.setCardTypeIconFromNumber = function (t) {
-    switch (CardJs.cardTypeFromNumber(t)) {
-      case "Visa Electron":
-      case "Visa":
-        this.setCardTypeAsVisa();
-        break;
-      case "Mastercard":
-        this.setCardTypeAsMasterCard();
-        break;
-      case "Maestro":
-        this.setCardTypeAsMaestro();
-        break;
-      case "Bcmc":
-        this.setCardTypeAsBcmc();
-        break;
-      case "AMEX":
-        this.setCardTypeAsAmericanExpress();
-        break;
-      case "Discover":
-        this.setCardTypeAsDiscover();
-        break;
-      case "Diners - Carte Blanche":
-      case "Diners":
-        this.setCardTypeAsDiners();
-        break;
-      case "JCB":
-        this.setCardTypeAsJcb();
-        break;
-      default:
-        this.clearCardType();
-    }
-  }),
-  (CardJs.prototype.setCardMask = function (t) {
-    (this.creditCardNumberMask = t),
-      this.cardNumberInput.attr("maxlength", t.length);
-  }),
-  (CardJs.prototype.setNoCvc = function () {
-    this.cvcInput.attr("disabled", "disabled");
-  }),
-  (CardJs.prototype.setCvc3 = function () {
-    this.cvcInput.removeAttr("disabled"),
-      this.cvcInput.attr("maxlength", CardJs.CVC_MASK_3.length);
-  }),
-  (CardJs.prototype.setCvc4 = function () {
-    this.cvcInput.removeAttr("disabled"),
-      this.cvcInput.attr("maxlength", CardJs.CVC_MASK_4.length);
-  }),
-  (CardJs.prototype.clearCardType = function () {
-    this.clearCardTypeIcon(),
-      this.setCardMask(CardJs.CREDIT_CARD_NUMBER_DEFAULT_MASK),
-      this.setCvc3();
-  }),
-  (CardJs.prototype.setCardTypeAsVisa = function () {
-    this.setCardTypeIconAsVisa(),
-      this.setCardMask(CardJs.CREDIT_CARD_NUMBER_VISA_MASK),
-      this.setCvc3();
-  }),
-  (CardJs.prototype.setCardTypeAsMasterCard = function () {
-    this.setCardTypeIconAsMasterCard(),
-      this.setCardMask(CardJs.CREDIT_CARD_NUMBER_MASTERCARD_MASK),
-      this.setCvc3();
-  }),
-  (CardJs.prototype.setCardTypeAsMaestro = function () {
-    this.setCardTypeIconAsMaestro(),
-      this.setCardMask(CardJs.CREDIT_CARD_NUMBER_MAESTRO_MASK),
-      this.setCvc3();
-  }),
-  (CardJs.prototype.setCardTypeAsBcmc = function () {
-    this.setCardTypeIconAsBcmc(),
-      this.setCardMask(CardJs.CREDIT_CARD_NUMBER_BCMC_MASK),
-      this.setNoCvc();
-  }),
-  (CardJs.prototype.setCardTypeAsAmericanExpress = function () {
-    this.setCardTypeIconAsAmericanExpress(),
-      this.setCardMask(CardJs.CREDIT_CARD_NUMBER_AMEX_MASK),
-      this.setCvc4();
-  }),
-  (CardJs.prototype.setCardTypeAsDiscover = function () {
-    this.setCardTypeIconAsDiscover(),
-      this.setCardMask(CardJs.CREDIT_CARD_NUMBER_DISCOVER_MASK),
-      this.setCvc3();
-  }),
-  (CardJs.prototype.setCardTypeAsDiners = function () {
-    this.setCardTypeIconAsDiners(),
-      this.setCardMask(CardJs.CREDIT_CARD_NUMBER_DINERS_MASK),
-      this.setCvc3();
-  }),
-  (CardJs.prototype.setCardTypeAsJcb = function () {
-    this.setCardTypeIconAsJcb(),
-      this.setCardMask(CardJs.CREDIT_CARD_NUMBER_JCB_MASK),
-      this.setCvc3();
-  }),
-  (CardJs.prototype.initCardNumberInput = function () {
-    var t = this;
-    (this.cardNumberInput = this.elem.find(".card-number")),
-      this.cardNumberInput[0]
-        ? this.cardNumberInput.detach()
-        : (this.cardNumberInput = $("<input class='card-number' />")),
-      this.cardNumberInput.attr("type", "tel"),
-      this.cardNumberInput.attr("placeholder") ||
-        this.cardNumberInput.attr(
-          "placeholder",
-          CardJs.CREDIT_CARD_NUMBER_PLACEHOLDER
-        ),
-      this.cardNumberInput.attr("maxlength", this.creditCardNumberMask.length),
-      this.cardNumberInput.attr("x-autocompletetype", "cc-number"),
-      this.cardNumberInput.attr("autocompletetype", "cc-number"),
-      this.cardNumberInput.attr("autocorrect", "off"),
-      this.cardNumberInput.attr("spellcheck", "off"),
-      this.cardNumberInput.attr("autocapitalize", "off"),
-      this.cardNumberInput.keydown(function (e) {
-        CardJs.handleCreditCardNumberKey(e, t.creditCardNumberMask);
-      }),
-      this.cardNumberInput.keyup(function (e) {
-        t.refreshCreditCardTypeIcon();
-      }),
-      this.cardNumberInput.on("paste", function () {
-        setTimeout(function () {
-          t.refreshCreditCardTypeIcon(), t.refreshCreditCardNumberFormat();
-        }, 1);
-      });
-  }),
-  (CardJs.prototype.initNameInput = function () {
-    (this.nameInput = this.elem.find(".name")),
-      this.nameInput[0]
-        ? ((this.captureName = !0), this.nameInput.detach())
-        : (this.nameInput = $("<input class='name' />")),
-      this.nameInput.attr("placeholder") ||
-        this.nameInput.attr("placeholder", CardJs.NAME_PLACEHOLDER);
-  }),
-  (CardJs.prototype.initExpiryMonthInput = function () {
-    (this.expiryMonthInput = this.elem.find(".expiry-month")),
-      this.expiryMonthInput[0]
-        ? this.expiryMonthInput.detach()
-        : (this.expiryMonthInput = $("<input class='expiry-month' />"));
-  }),
-  (CardJs.prototype.initExpiryYearInput = function () {
-    (this.expiryYearInput = this.elem.find(".expiry-year")),
-      this.expiryYearInput[0]
-        ? this.expiryYearInput.detach()
-        : (this.expiryYearInput = $("<input class='expiry-year' />"));
-  }),
-  (CardJs.prototype.initCvcInput = function () {
-    var t = this;
-    (this.cvcInput = this.elem.find(".cvc")),
-      this.cvcInput[0]
-        ? this.cvcInput.detach()
-        : (this.cvcInput = $("<input class='cvc' />")),
-      this.cvcInput.attr("type", "tel"),
-      this.cvcInput.attr("placeholder") ||
-        this.cvcInput.attr("placeholder", CardJs.CVC_PLACEHOLDER),
-      this.cvcInput.attr("maxlength", CardJs.CVC_MASK_3.length),
-      this.cvcInput.attr("x-autocompletetype", "cc-csc"),
-      this.cvcInput.attr("autocompletetype", "cc-csc"),
-      this.cvcInput.attr("autocorrect", "off"),
-      this.cvcInput.attr("spellcheck", "off"),
-      this.cvcInput.attr("autocapitalize", "off"),
-      this.cvcInput.keydown(CardJs.filterNumberOnlyKey),
-      this.cvcInput.on("paste", function () {
-        setTimeout(function () {
-          t.refreshCvc();
-        }, 1);
-      });
-  }),
-  (CardJs.prototype.setupCardNumberInput = function () {
-    this.stripe && this.cardNumberInput.attr("data-stripe", "number"),
-      this.elem.append("<div class='card-number-wrapper'></div>");
-    var t = this.elem.find(".card-number-wrapper");
-    t.append(this.cardNumberInput),
-      t.append("<div class='card-type-icon'></div>"),
-      t.append("<div class='icon'></div>"),
-      t.find(".icon").append(CardJs.CREDIT_CARD_SVG);
-  }),
-  (CardJs.prototype.setupNameInput = function () {
-    if (this.captureName) {
-      this.elem.append("<div class='name-wrapper'></div>");
-      var t = this.elem.find(".name-wrapper");
-      t.append(this.nameInput),
-        t.append("<div class='icon'></div>"),
-        t.find(".icon").append(CardJs.USER_SVG);
-    }
-  }),
-  (CardJs.prototype.setupExpiryInput = function () {
-    this.elem.append(
-      "<div class='expiry-container'><div class='expiry-wrapper'></div></div>"
-    );
-    var t,
-      e = this.elem.find(".expiry-wrapper");
-    if (CardJs.EXPIRY_USE_DROPDOWNS) {
-      t = $("<div></div>");
-      var r = $(
-          "<select name='expiry-month'><option value='any' selected='' hidden=''>" +
-            i18nMonth +
-            "</option><option value='01'>01</option><option value='02'>02</option><option value='03'>03</option><option value='04'>04</option><option value='05'>05</option><option value='06'>06</option><option value='07'>07</option><option value='08'>08</option><option value='09'>09</option><option value='10'>10</option><option value='11'>11</option><option value='12'>12</option></select>"
-        ),
-        a = this.expiryMonthInput;
-      CardJs.copyAllElementAttributes(a, r),
-        this.expiryMonthInput.remove(),
-        (this.expiryMonthInput = r);
-      for (
-        var s = $(
-            "<select name='expiry-year'><option value='any' selected='' hidden=''>" +
-              i18nYear +
-              "</option></select>"
-          ),
-          n = parseInt(new Date().getFullYear().toString().substring(2, 4)),
-          i = 0;
-        i < CardJs.EXPIRY_NUMBER_OF_YEARS;
-        i++
-      )
-        s.append("<option value='" + n + "'>" + n + "</option>"),
-          (n = (n + 1) % 100);
-      var p = this.expiryYearInput;
-      CardJs.copyAllElementAttributes(p, s),
-        this.expiryYearInput.remove(),
-        (this.expiryYearInput = s),
-        t.append(this.expiryMonthInput),
-        t.append(this.expiryYearInput);
-    } else {
-      (t = $("<div></div>")),
-        (this.expiryMonthInput = $(
-          "<input type='hidden' name='expiry-month' />"
-        )),
-        (this.expiryYearInput = $(
-          "<input type='hidden' name='expiry-year' />"
-        )),
-        this.stripe &&
-          (this.expiryMonthInput.attr("data-stripe", "exp-month"),
-          this.expiryYearInput.attr("data-stripe", "exp-year")),
-        (this.expiryMonthYearInput = $("<input class='expiry' />")),
-        this.expiryMonthYearInput.attr("type", "tel"),
-        this.expiryMonthYearInput.attr("placeholder") ||
-          this.expiryMonthYearInput.attr(
-            "placeholder",
-            CardJs.EXPIRY_PLACEHOLDER
-          ),
-        this.expiryMonthYearInput.attr("maxlength", CardJs.EXPIRY_MASK.length),
-        this.expiryMonthYearInput.attr("x-autocompletetype", "cc-exp"),
-        this.expiryMonthYearInput.attr("autocompletetype", "cc-exp"),
-        this.expiryMonthYearInput.attr("autocorrect", "off"),
-        this.expiryMonthYearInput.attr("spellcheck", "off"),
-        this.expiryMonthYearInput.attr("autocapitalize", "off");
-      var c = this;
-      this.expiryMonthYearInput.keydown(function (t) {
-        CardJs.handleExpiryKey(t);
-        var e = c.expiryMonthYearInput.val();
-        1 == e.length &&
-          parseInt(e) > 1 &&
-          CardJs.keyIsNumber(t) &&
-          c.expiryMonthYearInput.val(
-            CardJs.applyFormatMask("0" + e, CardJs.EXPIRY_MASK)
-          ),
-          c.EXPIRY_USE_DROPDOWNS ||
-            null == c.expiryMonthYearInput ||
-            (c.expiryMonthInput.val(c.expiryMonth()),
-            c.expiryYearInput.val(7 == e.length ? e.substr(5, 2) : null));
-      }),
-        this.expiryMonthYearInput.on("blur input", function (t) {
-          c.updateHiddenExpiryFields();
-        }),
-        this.cardNumberInput.on("blur input", function (t) {
-          c.updateHiddenExpiryFields();
-        }),
-        this.expiryMonthYearInput.blur(function (t) {
-          c.refreshExpiryMonthValidation();
-        }),
-        this.expiryMonthYearInput.on("paste", function () {
-          setTimeout(function () {
-            c.refreshExpiryMonthYearInput();
-          }, 1);
-        }),
-        t.append(this.expiryMonthYearInput),
-        t.append(this.expiryMonthInput),
-        t.append(this.expiryYearInput);
-    }
-    e.append(t),
-      e.append("<div class='icon'></div>"),
-      e.find(".icon").append(CardJs.CALENDAR_SVG);
-  }),
-  (CardJs.prototype.setupCvcInput = function () {
-    this.stripe && this.cvcInput.attr("data-stripe", "cvc"),
-      this.elem.append(
-        "<div class='cvc-container'><div class='cvc-wrapper'></div></div>"
+
+function initCardJs() {
+  function CardJs(t) {
+    (this.elem = jQuery(t)),
+      (this.captureName =
+        !!this.elem.data("capture-name") && this.elem.data("capture-name")),
+      (this.iconColour =
+        !!this.elem.data("icon-colour") && this.elem.data("icon-colour")),
+      (this.stripe = !!this.elem.data("stripe") && this.elem.data("stripe")),
+      this.stripe && (this.captureName = !1),
+      this.initCardNumberInput(),
+      this.initNameInput(),
+      this.initExpiryMonthInput(),
+      this.initExpiryYearInput(),
+      this.initCvcInput(),
+      this.elem.empty(),
+      this.setupCardNumberInput(),
+      this.setupNameInput(),
+      this.setupExpiryInput(),
+      this.setupCvcInput(),
+      this.iconColour && this.setIconColour(this.iconColour),
+      this.refreshCreditCardTypeIcon();
+  }
+  (CardJs.prototype.constructor = CardJs),
+    (CardJs.KEYS = {
+      0: 48,
+      9: 57,
+      NUMPAD_0: 96,
+      NUMPAD_9: 105,
+      DELETE: 46,
+      BACKSPACE: 8,
+      ARROW_LEFT: 37,
+      ARROW_RIGHT: 39,
+      ARROW_UP: 38,
+      ARROW_DOWN: 40,
+      HOME: 36,
+      END: 35,
+      TAB: 9,
+      A: 65,
+      X: 88,
+      C: 67,
+      V: 86
+    }),
+    (CardJs.CREDIT_CARD_NUMBER_DEFAULT_MASK = "XXXXXXXXXXXXXXXXXXXXXXXXX"),
+    (CardJs.CREDIT_CARD_NUMBER_VISA_MASK = "XXXX XXXX XXXX XXXX"),
+    (CardJs.CREDIT_CARD_NUMBER_MASTERCARD_MASK = "XXXX XXXX XXXX XXXX"),
+    (CardJs.CREDIT_CARD_NUMBER_MAESTRO_MASK = "XXXX XXXX XXXX XXXX XXX"),
+    (CardJs.CREDIT_CARD_NUMBER_BCMC_MASK = "XXXX XXXX XXXX XXXXX XXX"),
+    (CardJs.CREDIT_CARD_NUMBER_DISCOVER_MASK = "XXXX XXXX XXXX XXXX"),
+    (CardJs.CREDIT_CARD_NUMBER_JCB_MASK = "XXXX XXXX XXXX XXXX"),
+    (CardJs.CREDIT_CARD_NUMBER_AMEX_MASK = "XXXX XXXXXX XXXXX"),
+    (CardJs.CREDIT_CARD_NUMBER_DINERS_MASK = "XXXX XXXX XXXX XX"),
+    (CardJs.prototype.creditCardNumberMask =
+      CardJs.CREDIT_CARD_NUMBER_DEFAULT_MASK),
+    (CardJs.CREDIT_CARD_NUMBER_PLACEHOLDER = i18nCardNumber),
+    (CardJs.NAME_PLACEHOLDER = i18nNameOnCard),
+    (CardJs.EXPIRY_MASK = "XX / XX"),
+    (CardJs.EXPIRY_PLACEHOLDER = i18nDate),
+    (CardJs.EXPIRY_USE_DROPDOWNS = 1),
+    (CardJs.EXPIRY_NUMBER_OF_YEARS = 10),
+    (CardJs.CVC_MASK_3 = "XXX"),
+    (CardJs.CVC_MASK_4 = "XXXX"),
+    (CardJs.CVC_PLACEHOLDER = i18nCVC),
+    (CardJs.CREDIT_CARD_SVG =
+      '<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="3px" width="24px" height="17px" viewBox="0 0 216 146" enable-background="new 0 0 216 146" xml:space="preserve"><g><path class="svg" d="M182.385,14.258c-2.553-2.553-5.621-3.829-9.205-3.829H42.821c-3.585,0-6.653,1.276-9.207,3.829c-2.553,2.553-3.829,5.621-3.829,9.206v99.071c0,3.585,1.276,6.654,3.829,9.207c2.554,2.553,5.622,3.829,9.207,3.829H173.18c3.584,0,6.652-1.276,9.205-3.829s3.83-5.622,3.83-9.207V23.464C186.215,19.879,184.938,16.811,182.385,14.258z M175.785,122.536c0,0.707-0.258,1.317-0.773,1.834c-0.516,0.515-1.127,0.772-1.832,0.772H42.821c-0.706,0-1.317-0.258-1.833-0.773c-0.516-0.518-0.774-1.127-0.774-1.834V73h135.571V122.536z M175.785,41.713H40.214v-18.25c0-0.706,0.257-1.316,0.774-1.833c0.516-0.515,1.127-0.773,1.833-0.773H173.18c0.705,0,1.316,0.257,1.832,0.773c0.516,0.517,0.773,1.127,0.773,1.833V41.713z"/><rect class="svg" x="50.643" y="104.285" width="20.857" height="10.429"/><rect class="svg" x="81.929" y="104.285" width="31.286" height="10.429"/></g></svg>'),
+    (CardJs.LOCK_SVG =
+      '<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="3px" width="24px" height="17px" viewBox="0 0 216 146" enable-background="new 0 0 216 146" xml:space="preserve"><path class="svg" d="M152.646,70.067c-1.521-1.521-3.367-2.281-5.541-2.281H144.5V52.142c0-9.994-3.585-18.575-10.754-25.745c-7.17-7.17-15.751-10.755-25.746-10.755s-18.577,3.585-25.746,10.755C75.084,33.567,71.5,42.148,71.5,52.142v15.644h-2.607c-2.172,0-4.019,0.76-5.54,2.281c-1.521,1.52-2.281,3.367-2.281,5.541v46.929c0,2.172,0.76,4.019,2.281,5.54c1.521,1.52,3.368,2.281,5.54,2.281h78.214c2.174,0,4.02-0.76,5.541-2.281c1.52-1.521,2.281-3.368,2.281-5.54V75.607C154.93,73.435,154.168,71.588,152.646,70.067z M128.857,67.786H87.143V52.142c0-5.757,2.037-10.673,6.111-14.746c4.074-4.074,8.989-6.11,14.747-6.11s10.673,2.036,14.746,6.11c4.073,4.073,6.11,8.989,6.11,14.746V67.786z"/></svg>'),
+    (CardJs.CALENDAR_SVG =
+      '<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="4px" width="24px" height="16px" viewBox="0 0 216 146" enable-background="new 0 0 216 146" xml:space="preserve"><path class="svg" d="M172.691,23.953c-2.062-2.064-4.508-3.096-7.332-3.096h-10.428v-7.822c0-3.584-1.277-6.653-3.83-9.206c-2.554-2.553-5.621-3.83-9.207-3.83h-5.213c-3.586,0-6.654,1.277-9.207,3.83c-2.554,2.553-3.83,5.622-3.83,9.206v7.822H92.359v-7.822c0-3.584-1.277-6.653-3.83-9.206c-2.553-2.553-5.622-3.83-9.207-3.83h-5.214c-3.585,0-6.654,1.277-9.207,3.83c-2.553,2.553-3.83,5.622-3.83,9.206v7.822H50.643c-2.825,0-5.269,1.032-7.333,3.096s-3.096,4.509-3.096,7.333v104.287c0,2.823,1.032,5.267,3.096,7.332c2.064,2.064,4.508,3.096,7.333,3.096h114.714c2.824,0,5.27-1.032,7.332-3.096c2.064-2.064,3.096-4.509,3.096-7.332V31.286C175.785,28.461,174.754,26.017,172.691,23.953z M134.073,13.036c0-0.761,0.243-1.386,0.731-1.874c0.488-0.488,1.113-0.733,1.875-0.733h5.213c0.762,0,1.385,0.244,1.875,0.733c0.488,0.489,0.732,1.114,0.732,1.874V36.5c0,0.761-0.244,1.385-0.732,1.874c-0.49,0.488-1.113,0.733-1.875,0.733h-5.213c-0.762,0-1.387-0.244-1.875-0.733s-0.731-1.113-0.731-1.874V13.036z M71.501,13.036c0-0.761,0.244-1.386,0.733-1.874c0.489-0.488,1.113-0.733,1.874-0.733h5.214c0.761,0,1.386,0.244,1.874,0.733c0.488,0.489,0.733,1.114,0.733,1.874V36.5c0,0.761-0.244,1.386-0.733,1.874c-0.489,0.488-1.113,0.733-1.874,0.733h-5.214c-0.761,0-1.386-0.244-1.874-0.733c-0.488-0.489-0.733-1.113-0.733-1.874V13.036z M165.357,135.572H50.643V52.143h114.714V135.572z"/></svg>'),
+    (CardJs.USER_SVG =
+      '<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="4px" width="24px" height="16px" viewBox="0 0 216 146" enable-background="new 0 0 216 146" xml:space="preserve"><g><path class="svg" d="M107.999,73c8.638,0,16.011-3.056,22.12-9.166c6.111-6.11,9.166-13.483,9.166-22.12c0-8.636-3.055-16.009-9.166-22.12c-6.11-6.11-13.484-9.165-22.12-9.165c-8.636,0-16.01,3.055-22.12,9.165c-6.111,6.111-9.166,13.484-9.166,22.12c0,8.637,3.055,16.01,9.166,22.12C91.99,69.944,99.363,73,107.999,73z"/><path class="svg" d="M165.07,106.037c-0.191-2.743-0.571-5.703-1.141-8.881c-0.57-3.178-1.291-6.124-2.16-8.84c-0.869-2.715-2.037-5.363-3.504-7.943c-1.466-2.58-3.15-4.78-5.052-6.6s-4.223-3.272-6.965-4.358c-2.744-1.086-5.772-1.63-9.085-1.63c-0.489,0-1.63,0.584-3.422,1.752s-3.815,2.472-6.069,3.911c-2.254,1.438-5.188,2.743-8.799,3.909c-3.612,1.168-7.237,1.752-10.877,1.752c-3.639,0-7.264-0.584-10.876-1.752c-3.611-1.166-6.545-2.471-8.799-3.909c-2.254-1.439-4.277-2.743-6.069-3.911c-1.793-1.168-2.933-1.752-3.422-1.752c-3.313,0-6.341,0.544-9.084,1.63s-5.065,2.539-6.966,4.358c-1.901,1.82-3.585,4.02-5.051,6.6s-2.634,5.229-3.503,7.943c-0.869,2.716-1.589,5.662-2.159,8.84c-0.571,3.178-0.951,6.137-1.141,8.881c-0.19,2.744-0.285,5.554-0.285,8.433c0,6.517,1.983,11.664,5.948,15.439c3.965,3.774,9.234,5.661,15.806,5.661h71.208c6.572,0,11.84-1.887,15.806-5.661c3.966-3.775,5.948-8.921,5.948-15.439C165.357,111.591,165.262,108.78,165.07,106.037z"/></g></svg>'),
+    (CardJs.MAIL_SVG =
+      '<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"x="0px" y="4px" width="24px" height="16px" viewBox="0 0 216 146" enable-background="new 0 0 216 146" xml:space="preserve"><path class="svg" d="M177.171,19.472c-2.553-2.553-5.622-3.829-9.206-3.829H48.036c-3.585,0-6.654,1.276-9.207,3.829C36.276,22.025,35,25.094,35,28.679v88.644c0,3.585,1.276,6.652,3.829,9.205c2.553,2.555,5.622,3.83,9.207,3.83h119.929c3.584,0,6.653-1.275,9.206-3.83c2.554-2.553,3.829-5.621,3.829-9.205V28.679C181,25.094,179.725,22.025,177.171,19.472zM170.57,117.321c0,0.706-0.258,1.317-0.774,1.833s-1.127,0.773-1.832,0.773H48.035c-0.706,0-1.317-0.257-1.833-0.773c-0.516-0.516-0.774-1.127-0.774-1.833V54.75c1.738,1.955,3.612,3.748,5.622,5.377c14.557,11.189,26.126,20.368,34.708,27.538c2.77,2.336,5.024,4.155,6.762,5.459s4.087,2.62,7.047,3.951s5.744,1.995,8.351,1.995H108h0.081c2.606,0,5.392-0.664,8.351-1.995c2.961-1.331,5.311-2.647,7.049-3.951c1.737-1.304,3.992-3.123,6.762-5.459c8.582-7.17,20.15-16.349,34.707-27.538c2.01-1.629,3.885-3.422,5.621-5.377V117.321z M170.57,30.797v0.896c0,3.204-1.262,6.776-3.787,10.713c-2.525,3.938-5.256,7.075-8.188,9.41c-10.484,8.257-21.373,16.865-32.672,25.827c-0.326,0.271-1.277,1.073-2.852,2.403c-1.574,1.331-2.824,2.351-3.748,3.056c-0.924,0.707-2.131,1.562-3.625,2.566s-2.865,1.752-4.114,2.24s-2.417,0.732-3.503,0.732H108h-0.082c-1.086,0-2.253-0.244-3.503-0.732c-1.249-0.488-2.621-1.236-4.114-2.24c-1.493-1.004-2.702-1.859-3.625-2.566c-0.923-0.705-2.173-1.725-3.748-3.056c-1.575-1.33-2.526-2.132-2.852-2.403c-11.297-8.962-22.187-17.57-32.67-25.827c-7.985-6.3-11.977-14.013-11.977-23.138c0-0.706,0.258-1.317,0.774-1.833c0.516-0.516,1.127-0.774,1.833-0.774h119.929c0.434,0.244,0.814,0.312,1.141,0.204c0.326-0.11,0.57,0.094,0.732,0.61c0.163,0.516,0.312,0.76,0.448,0.733c0.136-0.027,0.218,0.312,0.245,1.019c0.025,0.706,0.039,1.061,0.039,1.061V30.797z"/></svg>'),
+    (CardJs.INFORMATION_SVG =
+      '<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="4px" width="24px" height="16px" viewBox="0 0 216 146" enable-background="new 0 0 216 146" xml:space="preserve"><g><path class="svg" d="M97.571,41.714h20.859c1.411,0,2.633-0.516,3.666-1.548c1.031-1.031,1.547-2.254,1.547-3.666V20.857c0-1.412-0.516-2.634-1.549-3.667c-1.031-1.031-2.254-1.548-3.666-1.548H97.571c-1.412,0-2.634,0.517-3.666,1.548c-1.032,1.032-1.548,2.255-1.548,3.667V36.5c0,1.412,0.516,2.635,1.548,3.666C94.937,41.198,96.159,41.714,97.571,41.714z"/><path class="svg" d="M132.523,111.048c-1.031-1.032-2.254-1.548-3.666-1.548h-5.215V62.571c0-1.412-0.516-2.634-1.547-3.666c-1.033-1.032-2.255-1.548-3.666-1.548H87.143c-1.412,0-2.634,0.516-3.666,1.548c-1.032,1.032-1.548,2.254-1.548,3.666V73c0,1.412,0.516,2.635,1.548,3.666c1.032,1.032,2.254,1.548,3.666,1.548h5.215V109.5h-5.215c-1.412,0-2.634,0.516-3.666,1.548c-1.032,1.032-1.548,2.254-1.548,3.666v10.429c0,1.412,0.516,2.635,1.548,3.668c1.032,1.03,2.254,1.547,3.666,1.547h41.714c1.412,0,2.634-0.517,3.666-1.547c1.031-1.033,1.547-2.256,1.547-3.668v-10.429C134.07,113.302,133.557,112.08,132.523,111.048z"/></g></svg>'),
+    (CardJs.keyCodeFromEvent = function (t) {
+      return t.which || t.keyCode;
+    }),
+    (CardJs.keyIsCommandFromEvent = function (t) {
+      return t.ctrlKey || t.metaKey;
+    }),
+    (CardJs.keyIsNumber = function (t) {
+      return CardJs.keyIsTopNumber(t) || CardJs.keyIsKeypadNumber(t);
+    }),
+    (CardJs.keyIsTopNumber = function (t) {
+      var e = CardJs.keyCodeFromEvent(t);
+      return e >= CardJs.KEYS[0] && e <= CardJs.KEYS[9];
+    }),
+    (CardJs.keyIsKeypadNumber = function (t) {
+      var e = CardJs.keyCodeFromEvent(t);
+      return e >= CardJs.KEYS.NUMPAD_0 && e <= CardJs.KEYS.NUMPAD_9;
+    }),
+    (CardJs.keyIsDelete = function (t) {
+      return CardJs.keyCodeFromEvent(t) == CardJs.KEYS.DELETE;
+    }),
+    (CardJs.keyIsBackspace = function (t) {
+      return CardJs.keyCodeFromEvent(t) == CardJs.KEYS.BACKSPACE;
+    }),
+    (CardJs.keyIsDeletion = function (t) {
+      return CardJs.keyIsDelete(t) || CardJs.keyIsBackspace(t);
+    }),
+    (CardJs.keyIsArrow = function (t) {
+      var e = CardJs.keyCodeFromEvent(t);
+      return e >= CardJs.KEYS.ARROW_LEFT && e <= CardJs.KEYS.ARROW_DOWN;
+    }),
+    (CardJs.keyIsNavigation = function (t) {
+      var e = CardJs.keyCodeFromEvent(t);
+      return e == CardJs.KEYS.HOME || e == CardJs.KEYS.END;
+    }),
+    (CardJs.keyIsKeyboardCommand = function (t) {
+      var e = CardJs.keyCodeFromEvent(t);
+      return (
+        CardJs.keyIsCommandFromEvent(t) &&
+        (e == CardJs.KEYS.A ||
+          e == CardJs.KEYS.X ||
+          e == CardJs.KEYS.C ||
+          e == CardJs.KEYS.V)
       );
-    var t = this.elem.find(".cvc-wrapper");
-    t.append(this.cvcInput),
-      t.append("<div class='icon'></div>"),
-      t.find(".icon").append(CardJs.LOCK_SVG);
-  }),
-  (CardJs.prototype.expiryMonth = function () {
-    if (!CardJs.EXPIRY_USE_DROPDOWNS && null != this.expiryMonthYearInput) {
-      var t = this.expiryMonthYearInput.val();
-      return t.length >= 2 ? parseInt(t.substr(0, 2)) : null;
-    }
-    return null;
-  }),
-  (CardJs.isValidMonth = function (t) {
-    return t >= 1 && t <= 12;
-  }),
-  (CardJs.isExpiryValid = function (t, e) {
-    var r = new Date(),
-      a = r.getMonth() + 1,
-      s = "" + r.getFullYear();
-    return (
-      2 == ("" + e).length && (e = s.substring(0, 2) + "" + e),
-      (a = parseInt(a)),
-      (s = parseInt(s)),
-      (t = parseInt(t)),
-      (e = parseInt(e)),
-      CardJs.isValidMonth(t) && (e > s || (e == s && t >= a))
-    );
-  }),
-  (CardJs.prototype.refreshExpiryMonthValidation = function () {
-    CardJs.isExpiryValid(this.getExpiryMonth(), this.getExpiryYear())
-      ? this.setExpiryMonthAsValid()
-      : this.setExpiryMonthAsInvalid();
-  }),
-  (CardJs.prototype.updateHiddenExpiryFields = function () {
-    var t = this.expiryMonthYearInput.val().match(/^\s*(\d+)\s*\/\s*(\d+)\s*$/);
-    if (null != t) {
-      var e = t[1],
-        r = t[2];
-      this.expiryMonthInput.val(e),
-        this.expiryYearInput.val(r),
-        this.expiryMonthYearInput.val(e + " / " + r);
-    }
-  }),
-  (CardJs.prototype.setExpiryMonthAsValid = function () {
-    CardJs.EXPIRY_USE_DROPDOWNS ||
-      this.expiryMonthYearInput.parent().removeClass("has-error");
-  }),
-  (CardJs.prototype.setExpiryMonthAsInvalid = function () {
-    CardJs.EXPIRY_USE_DROPDOWNS ||
-      this.expiryMonthYearInput.parent().addClass("has-error");
-  }),
-  (function (t) {
-    var e = {
-      init: function () {
-        return this.data("cardjs", new CardJs(this)), this;
-      },
-      cardNumber: function () {
-        return this.data("cardjs").getCardNumber();
-      },
-      cardType: function () {
-        return this.data("cardjs").getCardType();
-      },
-      name: function () {
-        return this.data("cardjs").getName();
-      },
-      expiryMonth: function () {
-        return this.data("cardjs").getExpiryMonth();
-      },
-      expiryYear: function () {
-        return this.data("cardjs").getExpiryYear();
-      },
-      cvc: function () {
-        return this.data("cardjs").getCvc();
+    }),
+    (CardJs.keyIsTab = function (t) {
+      return CardJs.keyCodeFromEvent(t) == CardJs.KEYS.TAB;
+    }),
+    (CardJs.copyAllElementAttributes = function (t, e) {
+      $.each(t[0].attributes, function (t, r) {
+        e.attr(r.nodeName, r.nodeValue);
+      });
+    }),
+    (CardJs.numbersOnlyString = function (t) {
+      for (var e = "", r = 0; r < t.length; r++) {
+        var a = t.charAt(r);
+        !isNaN(parseInt(a)) && (e += a);
       }
-    };
-    t.fn.CardJs = function (r) {
-      return e[r]
-        ? e[r].apply(this, Array.prototype.slice.call(arguments, 1))
-        : "object" != typeof r && r
-        ? void t.error("Method " + r + " does not exist on jQuery.CardJs")
-        : e.init.apply(this, arguments);
-    };
-  })(jQuery),
-  jQuery(function ($) {
+      return e;
+    }),
+    (CardJs.applyFormatMask = function (t, e) {
+      for (var r = "", a = 0, s = 0; s < e.length; s++) {
+        var n = e[s];
+        if ("X" == n) {
+          if (!t.charAt(a)) break;
+          (r += t.charAt(a)), a++;
+        } else r += n;
+      }
+      return r;
+    }),
+    (CardJs.cardTypeFromNumber = function (t) {
+      if (((e = new RegExp("^30[0-5]")), null != t.match(e)))
+        return "Diners - Carte Blanche";
+      if (((e = new RegExp("^(30[6-9]|36|38)")), null != t.match(e)))
+        return "Diners";
+      if (((e = new RegExp("^35(2[89]|[3-8][0-9])")), null != t.match(e)))
+        return "JCB";
+      if (((e = new RegExp("^3[47]")), null != t.match(e))) return "AMEX";
+      if (
+        ((e = new RegExp("^(4026|417500|4508|4844|491(3|7))")),
+        null != t.match(e))
+      )
+        return "Visa Electron";
+      var e = new RegExp("^4");
+      return null != t.match(e)
+        ? "Visa"
+        : ((e = new RegExp(
+            "^(?:5[1-5][0-9]{2}|222[1-9]|22[3-9][0-9]|2[3-6][0-9]{2}|27[01][0-9]|2720)"
+          )),
+          null != t.match(e)
+            ? "Mastercard"
+            : ((e = new RegExp(
+                "^(6011|622(12[6-9]|1[3-9][0-9]|[2-8][0-9]{2}|9[0-1][0-9]|92[0-5]|64[4-9])|65)"
+              )),
+              null != t.match(e)
+                ? "Discover"
+                : ((e = new RegExp("^(6703)")),
+                  null != t.match(e)
+                    ? "Bcmc"
+                    : ((e = new RegExp("^(5[0678]\\d\\d|6304|6390|67\\d\\d)")),
+                      null != t.match(e) ? "Maestro" : ""))));
+    }),
+    (CardJs.caretStartPosition = function (t) {
+      return "number" == typeof t.selectionStart && t.selectionStart;
+    }),
+    (CardJs.caretEndPosition = function (t) {
+      return "number" == typeof t.selectionEnd && t.selectionEnd;
+    }),
+    (CardJs.setCaretPosition = function (t, e) {
+      if (null != t)
+        if (t.createTextRange) {
+          var r = t.createTextRange();
+          r.move("character", e), r.select();
+        } else
+          t.selectionStart ? (t.focus(), t.setSelectionRange(e, e)) : t.focus();
+    }),
+    (CardJs.normaliseCaretPosition = function (t, e) {
+      var r = 0;
+      if (e < 0 || e > t.length) return 0;
+      for (var a = 0; a < t.length; a++) {
+        if (a == e) return r;
+        "X" == t[a] && r++;
+      }
+      return r;
+    }),
+    (CardJs.denormaliseCaretPosition = function (t, e) {
+      var r = 0;
+      if (e < 0 || e > t.length) return 0;
+      for (var a = 0; a < t.length; a++) {
+        if (r == e) return a;
+        "X" == t[a] && r++;
+      }
+      return t.length;
+    }),
+    (CardJs.filterNumberOnlyKey = function (t) {
+      var e = CardJs.keyIsNumber(t),
+        r = CardJs.keyIsDeletion(t),
+        a = CardJs.keyIsArrow(t),
+        s = CardJs.keyIsNavigation(t),
+        n = CardJs.keyIsKeyboardCommand(t),
+        i = CardJs.keyIsTab(t);
+      e || r || a || s || n || i || t.preventDefault();
+    }),
+    (CardJs.digitFromKeyCode = function (t) {
+      return t >= CardJs.KEYS[0] && t <= CardJs.KEYS[9]
+        ? t - CardJs.KEYS[0]
+        : t >= CardJs.KEYS.NUMPAD_0 && t <= CardJs.KEYS.NUMPAD_9
+        ? t - CardJs.KEYS.NUMPAD_0
+        : null;
+    }),
+    (CardJs.handleMaskedNumberInputKey = function (t, e) {
+      CardJs.filterNumberOnlyKey(t);
+      var r = t.which || t.keyCode,
+        a = t.target,
+        s = CardJs.caretStartPosition(a),
+        n = CardJs.caretEndPosition(a),
+        i = CardJs.normaliseCaretPosition(e, s),
+        p = CardJs.normaliseCaretPosition(e, n),
+        c = s,
+        o = CardJs.keyIsNumber(t),
+        d = CardJs.keyIsDelete(t),
+        u = CardJs.keyIsBackspace(t);
+      if (o || d || u) {
+        t.preventDefault();
+        var C = $(a).val(),
+          h = CardJs.numbersOnlyString(C),
+          l = CardJs.digitFromKeyCode(r),
+          y = p > i;
+        y && (h = h.slice(0, i) + h.slice(p)),
+          s != e.length &&
+            (o &&
+              C.length <= e.length &&
+              ((h = h.slice(0, i) + l + h.slice(i)),
+              (c = Math.max(
+                CardJs.denormaliseCaretPosition(e, i + 1),
+                CardJs.denormaliseCaretPosition(e, i + 2) - 1
+              ))),
+            d && (h = h.slice(0, i) + h.slice(i + 1))),
+          0 != s &&
+            u &&
+            !y &&
+            ((h = h.slice(0, i - 1) + h.slice(i)),
+            (c = CardJs.denormaliseCaretPosition(e, i - 1))),
+          $(a).val(CardJs.applyFormatMask(h, e)),
+          CardJs.setCaretPosition(a, c);
+      }
+    }),
+    (CardJs.handleCreditCardNumberKey = function (t, e) {
+      CardJs.handleMaskedNumberInputKey(t, e);
+    }),
+    (CardJs.handleCreditCardNumberChange = function (t) {}),
+    (CardJs.handleExpiryKey = function (t) {
+      CardJs.handleMaskedNumberInputKey(t, CardJs.EXPIRY_MASK);
+    }),
+    (CardJs.prototype.getCardNumber = function () {
+      return this.cardNumberInput.val();
+    }),
+    (CardJs.prototype.getCardType = function () {
+      return CardJs.cardTypeFromNumber(this.getCardNumber());
+    }),
+    (CardJs.prototype.getName = function () {
+      return this.nameInput.val();
+    }),
+    (CardJs.prototype.getExpiryMonth = function () {
+      return this.expiryMonthInput.val();
+    }),
+    (CardJs.prototype.getExpiryYear = function () {
+      return this.expiryYearInput.val();
+    }),
+    (CardJs.prototype.getCvc = function () {
+      return this.cvcInput.val();
+    }),
+    (CardJs.prototype.setIconColour = function (t) {
+      this.elem.find(".icon .svg").css({ fill: t });
+    }),
+    (CardJs.prototype.setIconColour = function (t) {
+      this.elem.find(".icon .svg").css({ fill: t });
+    }),
+    (CardJs.prototype.refreshCreditCardTypeIcon = function () {
+      this.setCardTypeIconFromNumber(
+        CardJs.numbersOnlyString(this.cardNumberInput.val())
+      );
+    }),
+    (CardJs.prototype.refreshCreditCardNumberFormat = function () {
+      var t = CardJs.numbersOnlyString($(this.cardNumberInput).val()),
+        e = CardJs.applyFormatMask(t, this.creditCardNumberMask);
+      $(this.cardNumberInput).val(e);
+    }),
+    (CardJs.prototype.refreshExpiryMonthYearInput = function () {
+      var t = CardJs.numbersOnlyString($(this.expiryMonthYearInput).val()),
+        e = CardJs.applyFormatMask(t, CardJs.EXPIRY_MASK);
+      $(this.expiryMonthYearInput).val(e);
+    }),
+    (CardJs.prototype.refreshCvc = function () {
+      var t = CardJs.numbersOnlyString($(this.cvcInput).val()),
+        e = CardJs.applyFormatMask(t, this.creditCardNumberMask);
+      $(this.cvcInput).val(e);
+    }),
+    (CardJs.prototype.clearCardTypeIcon = function () {
+      this.elem.find(".card-number-wrapper .card-type-icon").removeClass("show");
+    }),
+    (CardJs.prototype.setCardTypeIconAsVisa = function () {
+      this.elem
+        .find(".card-number-wrapper .card-type-icon")
+        .attr("class", "card-type-icon show visa");
+    }),
+    (CardJs.prototype.setCardTypeIconAsMasterCard = function () {
+      this.elem
+        .find(".card-number-wrapper .card-type-icon")
+        .attr("class", "card-type-icon show master-card");
+    }),
+    (CardJs.prototype.setCardTypeIconAsMaestro = function () {
+      this.elem
+        .find(".card-number-wrapper .card-type-icon")
+        .attr("class", "card-type-icon show maestro");
+    }),
+    (CardJs.prototype.setCardTypeIconAsBcmc = function () {
+      this.elem
+        .find(".card-number-wrapper .card-type-icon")
+        .attr("class", "card-type-icon show bcmc");
+    }),
+    (CardJs.prototype.setCardTypeIconAsAmericanExpress = function () {
+      this.elem
+        .find(".card-number-wrapper .card-type-icon")
+        .attr("class", "card-type-icon show american-express");
+    }),
+    (CardJs.prototype.setCardTypeIconAsDiscover = function () {
+      this.elem
+        .find(".card-number-wrapper .card-type-icon")
+        .attr("class", "card-type-icon show discover");
+    }),
+    (CardJs.prototype.setCardTypeIconAsDiners = function () {
+      this.elem
+        .find(".card-number-wrapper .card-type-icon")
+        .attr("class", "card-type-icon show diners");
+    }),
+    (CardJs.prototype.setCardTypeIconAsJcb = function () {
+      this.elem
+        .find(".card-number-wrapper .card-type-icon")
+        .attr("class", "card-type-icon show jcb");
+    }),
+    (CardJs.prototype.setCardTypeIconFromNumber = function (t) {
+      switch (CardJs.cardTypeFromNumber(t)) {
+        case "Visa Electron":
+        case "Visa":
+          this.setCardTypeAsVisa();
+          break;
+        case "Mastercard":
+          this.setCardTypeAsMasterCard();
+          break;
+        case "Maestro":
+          this.setCardTypeAsMaestro();
+          break;
+        case "Bcmc":
+          this.setCardTypeAsBcmc();
+          break;
+        case "AMEX":
+          this.setCardTypeAsAmericanExpress();
+          break;
+        case "Discover":
+          this.setCardTypeAsDiscover();
+          break;
+        case "Diners - Carte Blanche":
+        case "Diners":
+          this.setCardTypeAsDiners();
+          break;
+        case "JCB":
+          this.setCardTypeAsJcb();
+          break;
+        default:
+          this.clearCardType();
+      }
+    }),
+    (CardJs.prototype.setCardMask = function (t) {
+      (this.creditCardNumberMask = t),
+        this.cardNumberInput.attr("maxlength", t.length);
+    }),
+    (CardJs.prototype.setNoCvc = function () {
+      this.cvcInput.attr("disabled", "disabled");
+    }),
+    (CardJs.prototype.setCvc3 = function () {
+      this.cvcInput.removeAttr("disabled"),
+        this.cvcInput.attr("maxlength", CardJs.CVC_MASK_3.length);
+    }),
+    (CardJs.prototype.setCvc4 = function () {
+      this.cvcInput.removeAttr("disabled"),
+        this.cvcInput.attr("maxlength", CardJs.CVC_MASK_4.length);
+    }),
+    (CardJs.prototype.clearCardType = function () {
+      this.clearCardTypeIcon(),
+        this.setCardMask(CardJs.CREDIT_CARD_NUMBER_DEFAULT_MASK),
+        this.setCvc3();
+    }),
+    (CardJs.prototype.setCardTypeAsVisa = function () {
+      this.setCardTypeIconAsVisa(),
+        this.setCardMask(CardJs.CREDIT_CARD_NUMBER_VISA_MASK),
+        this.setCvc3();
+    }),
+    (CardJs.prototype.setCardTypeAsMasterCard = function () {
+      this.setCardTypeIconAsMasterCard(),
+        this.setCardMask(CardJs.CREDIT_CARD_NUMBER_MASTERCARD_MASK),
+        this.setCvc3();
+    }),
+    (CardJs.prototype.setCardTypeAsMaestro = function () {
+      this.setCardTypeIconAsMaestro(),
+        this.setCardMask(CardJs.CREDIT_CARD_NUMBER_MAESTRO_MASK),
+        this.setCvc3();
+    }),
+    (CardJs.prototype.setCardTypeAsBcmc = function () {
+      this.setCardTypeIconAsBcmc(),
+        this.setCardMask(CardJs.CREDIT_CARD_NUMBER_BCMC_MASK),
+        this.setNoCvc();
+    }),
+    (CardJs.prototype.setCardTypeAsAmericanExpress = function () {
+      this.setCardTypeIconAsAmericanExpress(),
+        this.setCardMask(CardJs.CREDIT_CARD_NUMBER_AMEX_MASK),
+        this.setCvc4();
+    }),
+    (CardJs.prototype.setCardTypeAsDiscover = function () {
+      this.setCardTypeIconAsDiscover(),
+        this.setCardMask(CardJs.CREDIT_CARD_NUMBER_DISCOVER_MASK),
+        this.setCvc3();
+    }),
+    (CardJs.prototype.setCardTypeAsDiners = function () {
+      this.setCardTypeIconAsDiners(),
+        this.setCardMask(CardJs.CREDIT_CARD_NUMBER_DINERS_MASK),
+        this.setCvc3();
+    }),
+    (CardJs.prototype.setCardTypeAsJcb = function () {
+      this.setCardTypeIconAsJcb(),
+        this.setCardMask(CardJs.CREDIT_CARD_NUMBER_JCB_MASK),
+        this.setCvc3();
+    }),
+    (CardJs.prototype.initCardNumberInput = function () {
+      var t = this;
+      (this.cardNumberInput = this.elem.find(".card-number")),
+        this.cardNumberInput[0]
+          ? this.cardNumberInput.detach()
+          : (this.cardNumberInput = $("<input class='card-number' />")),
+        this.cardNumberInput.attr("type", "tel"),
+        this.cardNumberInput.attr("placeholder") ||
+          this.cardNumberInput.attr(
+            "placeholder",
+            CardJs.CREDIT_CARD_NUMBER_PLACEHOLDER
+          ),
+        this.cardNumberInput.attr("maxlength", this.creditCardNumberMask.length),
+        this.cardNumberInput.attr("x-autocompletetype", "cc-number"),
+        this.cardNumberInput.attr("autocompletetype", "cc-number"),
+        this.cardNumberInput.attr("autocorrect", "off"),
+        this.cardNumberInput.attr("spellcheck", "off"),
+        this.cardNumberInput.attr("autocapitalize", "off"),
+        this.cardNumberInput.keydown(function (e) {
+          CardJs.handleCreditCardNumberKey(e, t.creditCardNumberMask);
+        }),
+        this.cardNumberInput.keyup(function (e) {
+          t.refreshCreditCardTypeIcon();
+        }),
+        this.cardNumberInput.on("paste", function () {
+          setTimeout(function () {
+            t.refreshCreditCardTypeIcon(), t.refreshCreditCardNumberFormat();
+          }, 1);
+        });
+    }),
+    (CardJs.prototype.initNameInput = function () {
+      (this.nameInput = this.elem.find(".name")),
+        this.nameInput[0]
+          ? ((this.captureName = !0), this.nameInput.detach())
+          : (this.nameInput = $("<input class='name' />")),
+        this.nameInput.attr("placeholder") ||
+          this.nameInput.attr("placeholder", CardJs.NAME_PLACEHOLDER);
+    }),
+    (CardJs.prototype.initExpiryMonthInput = function () {
+      (this.expiryMonthInput = this.elem.find(".expiry-month")),
+        this.expiryMonthInput[0]
+          ? this.expiryMonthInput.detach()
+          : (this.expiryMonthInput = $("<input class='expiry-month' />"));
+    }),
+    (CardJs.prototype.initExpiryYearInput = function () {
+      (this.expiryYearInput = this.elem.find(".expiry-year")),
+        this.expiryYearInput[0]
+          ? this.expiryYearInput.detach()
+          : (this.expiryYearInput = $("<input class='expiry-year' />"));
+    }),
+    (CardJs.prototype.initCvcInput = function () {
+      var t = this;
+      (this.cvcInput = this.elem.find(".cvc")),
+        this.cvcInput[0]
+          ? this.cvcInput.detach()
+          : (this.cvcInput = $("<input class='cvc' />")),
+        this.cvcInput.attr("type", "tel"),
+        this.cvcInput.attr("placeholder") ||
+          this.cvcInput.attr("placeholder", CardJs.CVC_PLACEHOLDER),
+        this.cvcInput.attr("maxlength", CardJs.CVC_MASK_3.length),
+        this.cvcInput.attr("x-autocompletetype", "cc-csc"),
+        this.cvcInput.attr("autocompletetype", "cc-csc"),
+        this.cvcInput.attr("autocorrect", "off"),
+        this.cvcInput.attr("spellcheck", "off"),
+        this.cvcInput.attr("autocapitalize", "off"),
+        this.cvcInput.keydown(CardJs.filterNumberOnlyKey),
+        this.cvcInput.on("paste", function () {
+          setTimeout(function () {
+            t.refreshCvc();
+          }, 1);
+        });
+    }),
+    (CardJs.prototype.setupCardNumberInput = function () {
+      this.stripe && this.cardNumberInput.attr("data-stripe", "number"),
+        this.elem.append("<div class='card-number-wrapper'></div>");
+      var t = this.elem.find(".card-number-wrapper");
+      t.append(this.cardNumberInput),
+        t.append("<div class='card-type-icon'></div>"),
+        t.append("<div class='icon'></div>"),
+        t.find(".icon").append(CardJs.CREDIT_CARD_SVG);
+    }),
+    (CardJs.prototype.setupNameInput = function () {
+      if (this.captureName) {
+        this.elem.append("<div class='name-wrapper'></div>");
+        var t = this.elem.find(".name-wrapper");
+        t.append(this.nameInput),
+          t.append("<div class='icon'></div>"),
+          t.find(".icon").append(CardJs.USER_SVG);
+      }
+    }),
+    (CardJs.prototype.setupExpiryInput = function () {
+      this.elem.append(
+        "<div class='expiry-container'><div class='expiry-wrapper'></div></div>"
+      );
+      var t,
+        e = this.elem.find(".expiry-wrapper");
+      if (CardJs.EXPIRY_USE_DROPDOWNS) {
+        t = $("<div></div>");
+        var r = $(
+            "<select name='expiry-month'><option value='any' selected='' hidden=''>" +
+              i18nMonth +
+              "</option><option value='01'>01</option><option value='02'>02</option><option value='03'>03</option><option value='04'>04</option><option value='05'>05</option><option value='06'>06</option><option value='07'>07</option><option value='08'>08</option><option value='09'>09</option><option value='10'>10</option><option value='11'>11</option><option value='12'>12</option></select>"
+          ),
+          a = this.expiryMonthInput;
+        CardJs.copyAllElementAttributes(a, r),
+          this.expiryMonthInput.remove(),
+          (this.expiryMonthInput = r);
+        for (
+          var s = $(
+              "<select name='expiry-year'><option value='any' selected='' hidden=''>" +
+                i18nYear +
+                "</option></select>"
+            ),
+            n = parseInt(new Date().getFullYear().toString().substring(2, 4)),
+            i = 0;
+          i < CardJs.EXPIRY_NUMBER_OF_YEARS;
+          i++
+        )
+          s.append("<option value='" + n + "'>" + n + "</option>"),
+            (n = (n + 1) % 100);
+        var p = this.expiryYearInput;
+        CardJs.copyAllElementAttributes(p, s),
+          this.expiryYearInput.remove(),
+          (this.expiryYearInput = s),
+          t.append(this.expiryMonthInput),
+          t.append(this.expiryYearInput);
+      } else {
+        (t = $("<div></div>")),
+          (this.expiryMonthInput = $(
+            "<input type='hidden' name='expiry-month' />"
+          )),
+          (this.expiryYearInput = $(
+            "<input type='hidden' name='expiry-year' />"
+          )),
+          this.stripe &&
+            (this.expiryMonthInput.attr("data-stripe", "exp-month"),
+            this.expiryYearInput.attr("data-stripe", "exp-year")),
+          (this.expiryMonthYearInput = $("<input class='expiry' />")),
+          this.expiryMonthYearInput.attr("type", "tel"),
+          this.expiryMonthYearInput.attr("placeholder") ||
+            this.expiryMonthYearInput.attr(
+              "placeholder",
+              CardJs.EXPIRY_PLACEHOLDER
+            ),
+          this.expiryMonthYearInput.attr("maxlength", CardJs.EXPIRY_MASK.length),
+          this.expiryMonthYearInput.attr("x-autocompletetype", "cc-exp"),
+          this.expiryMonthYearInput.attr("autocompletetype", "cc-exp"),
+          this.expiryMonthYearInput.attr("autocorrect", "off"),
+          this.expiryMonthYearInput.attr("spellcheck", "off"),
+          this.expiryMonthYearInput.attr("autocapitalize", "off");
+        var c = this;
+        this.expiryMonthYearInput.keydown(function (t) {
+          CardJs.handleExpiryKey(t);
+          var e = c.expiryMonthYearInput.val();
+          1 == e.length &&
+            parseInt(e) > 1 &&
+            CardJs.keyIsNumber(t) &&
+            c.expiryMonthYearInput.val(
+              CardJs.applyFormatMask("0" + e, CardJs.EXPIRY_MASK)
+            ),
+            c.EXPIRY_USE_DROPDOWNS ||
+              null == c.expiryMonthYearInput ||
+              (c.expiryMonthInput.val(c.expiryMonth()),
+              c.expiryYearInput.val(7 == e.length ? e.substr(5, 2) : null));
+        }),
+          this.expiryMonthYearInput.on("blur input", function (t) {
+            c.updateHiddenExpiryFields();
+          }),
+          this.cardNumberInput.on("blur input", function (t) {
+            c.updateHiddenExpiryFields();
+          }),
+          this.expiryMonthYearInput.blur(function (t) {
+            c.refreshExpiryMonthValidation();
+          }),
+          this.expiryMonthYearInput.on("paste", function () {
+            setTimeout(function () {
+              c.refreshExpiryMonthYearInput();
+            }, 1);
+          }),
+          t.append(this.expiryMonthYearInput),
+          t.append(this.expiryMonthInput),
+          t.append(this.expiryYearInput);
+      }
+      e.append(t),
+        e.append("<div class='icon'></div>"),
+        e.find(".icon").append(CardJs.CALENDAR_SVG);
+    }),
+    (CardJs.prototype.setupCvcInput = function () {
+      this.stripe && this.cvcInput.attr("data-stripe", "cvc"),
+        this.elem.append(
+          "<div class='cvc-container'><div class='cvc-wrapper'></div></div>"
+        );
+      var t = this.elem.find(".cvc-wrapper");
+      t.append(this.cvcInput),
+        t.append("<div class='icon'></div>"),
+        t.find(".icon").append(CardJs.LOCK_SVG);
+    }),
+    (CardJs.prototype.expiryMonth = function () {
+      if (!CardJs.EXPIRY_USE_DROPDOWNS && null != this.expiryMonthYearInput) {
+        var t = this.expiryMonthYearInput.val();
+        return t.length >= 2 ? parseInt(t.substr(0, 2)) : null;
+      }
+      return null;
+    }),
+    (CardJs.isValidMonth = function (t) {
+      return t >= 1 && t <= 12;
+    }),
+    (CardJs.isExpiryValid = function (t, e) {
+      var r = new Date(),
+        a = r.getMonth() + 1,
+        s = "" + r.getFullYear();
+      return (
+        2 == ("" + e).length && (e = s.substring(0, 2) + "" + e),
+        (a = parseInt(a)),
+        (s = parseInt(s)),
+        (t = parseInt(t)),
+        (e = parseInt(e)),
+        CardJs.isValidMonth(t) && (e > s || (e == s && t >= a))
+      );
+    }),
+    (CardJs.prototype.refreshExpiryMonthValidation = function () {
+      CardJs.isExpiryValid(this.getExpiryMonth(), this.getExpiryYear())
+        ? this.setExpiryMonthAsValid()
+        : this.setExpiryMonthAsInvalid();
+    }),
+    (CardJs.prototype.updateHiddenExpiryFields = function () {
+      var t = this.expiryMonthYearInput.val().match(/^\s*(\d+)\s*\/\s*(\d+)\s*$/);
+      if (null != t) {
+        var e = t[1],
+          r = t[2];
+        this.expiryMonthInput.val(e),
+          this.expiryYearInput.val(r),
+          this.expiryMonthYearInput.val(e + " / " + r);
+      }
+    }),
+    (CardJs.prototype.setExpiryMonthAsValid = function () {
+      CardJs.EXPIRY_USE_DROPDOWNS ||
+        this.expiryMonthYearInput.parent().removeClass("has-error");
+    }),
+    (CardJs.prototype.setExpiryMonthAsInvalid = function () {
+      CardJs.EXPIRY_USE_DROPDOWNS ||
+        this.expiryMonthYearInput.parent().addClass("has-error");
+    }),
+    (function (t) {
+      var e = {
+        init: function () {
+          return this.data("cardjs", new CardJs(this)), this;
+        },
+        cardNumber: function () {
+          return this.data("cardjs").getCardNumber();
+        },
+        cardType: function () {
+          return this.data("cardjs").getCardType();
+        },
+        name: function () {
+          return this.data("cardjs").getName();
+        },
+        expiryMonth: function () {
+          return this.data("cardjs").getExpiryMonth();
+        },
+        expiryYear: function () {
+          return this.data("cardjs").getExpiryYear();
+        },
+        cvc: function () {
+          return this.data("cardjs").getCvc();
+        }
+      };
+      t.fn.CardJs = function (r) {
+        return e[r]
+          ? e[r].apply(this, Array.prototype.slice.call(arguments, 1))
+          : "object" != typeof r && r
+          ? void t.error("Method " + r + " does not exist on jQuery.CardJs")
+          : e.init.apply(this, arguments);
+      };
+    })(jQuery);
+
     $(".card-js").each(function (t, e) {
       $(e).CardJs();
     });
-  });
+}
+
+jQuery(function ($) {
+  initCardJs();
+});
+
+//Support module One Page Checkout
+//--------------------------------
+window.opc_dispatcher.events.addEventListener('payment-getPaymentList-complete', () => {
+  initCardJs();
+});
+$(document).on('opc-load-payment:completed', function() {
+  initCardJs();
+});
+//--------------------------------
+
 window.Jquery = jQuery;

--- a/src/hipay_enterprise/views/js/card-js.min.js
+++ b/src/hipay_enterprise/views/js/card-js.min.js
@@ -742,12 +742,9 @@ jQuery(function ($) {
   initCardJs();
 });
 
-//Support module One Page Checkout
+//Support module One Page Checkout PS - PresTeamShop - v4.1.1 - PrestaShop >= 1.7.6.X
 //--------------------------------
 window.opc_dispatcher.events.addEventListener('payment-getPaymentList-complete', () => {
-  initCardJs();
-});
-$(document).on('opc-load-payment:completed', function() {
   initCardJs();
 });
 //--------------------------------

--- a/src/hipay_enterprise/views/js/card-tokenize.js
+++ b/src/hipay_enterprise/views/js/card-tokenize.js
@@ -104,12 +104,9 @@ jQuery(document).ready(function ($) {
   initDirectPost();
 });
 
-//Support module One Page Checkout
+//Support module One Page Checkout PS - PresTeamShop - v4.1.1 - PrestaShop >= 1.7.6.X
 //--------------------------------
 window.opc_dispatcher.events.addEventListener('payment-getPaymentList-complete', () => {
-  initDirectPost();
-});
-$(document).on('opc-load-payment:completed', function() {
   initDirectPost();
 });
 //--------------------------------

--- a/src/hipay_enterprise/views/js/card-tokenize.js
+++ b/src/hipay_enterprise/views/js/card-tokenize.js
@@ -9,7 +9,8 @@
  * @copyright 2017 HiPay
  * @license   https://github.com/hipay/hipay-enterprise-sdk-prestashop/blob/master/LICENSE.md
  */
-jQuery(document).ready(function ($) {
+
+function initDirectPost() {
   $("#card-number").focus(function () {
     $("#radio-no-token").prop("checked", true);
   });
@@ -97,4 +98,18 @@ jQuery(document).ready(function ($) {
       );
     }
   });
+}
+
+jQuery(document).ready(function ($) {
+  initDirectPost();
 });
+
+//Support module One Page Checkout
+//--------------------------------
+window.opc_dispatcher.events.addEventListener('payment-getPaymentList-complete', () => {
+  initDirectPost();
+});
+$(document).on('opc-load-payment:completed', function() {
+  initDirectPost();
+});
+//--------------------------------

--- a/src/hipay_enterprise/views/js/hosted-fields.js
+++ b/src/hipay_enterprise/views/js/hosted-fields.js
@@ -57,13 +57,9 @@ var hipayHF;
 
 document.addEventListener('DOMContentLoaded', initHostedFields, false);
 
-//Support module One Page Checkout
+//Support module One Page Checkout PS - PresTeamShop - v4.1.1 - PrestaShop >= 1.7.6.X
 //--------------------------------
 window.opc_dispatcher.events.addEventListener('payment-getPaymentList-complete', () => {
-  initEventsHostedFields();
-  initHostedFields();
-});
-$(document).on('opc-load-payment:completed', function() {
   initEventsHostedFields();
   initHostedFields();
 });

--- a/src/hipay_enterprise/views/js/hosted-fields.js
+++ b/src/hipay_enterprise/views/js/hosted-fields.js
@@ -1,4 +1,8 @@
 jQuery(document).ready(function ($) {
+  initEventsHostedFields();
+});
+
+function initEventsHostedFields() {
   $('#card-number').focus(function () {
     $('#radio-no-token').prop('checked', true);
   });
@@ -47,10 +51,23 @@ jQuery(document).ready(function ($) {
       );
     }
   });
-});
+}
+
 var hipayHF;
 
 document.addEventListener('DOMContentLoaded', initHostedFields, false);
+
+//Support module One Page Checkout
+//--------------------------------
+window.opc_dispatcher.events.addEventListener('payment-getPaymentList-complete', () => {
+  initEventsHostedFields();
+  initHostedFields();
+});
+$(document).on('opc-load-payment:completed', function() {
+  initEventsHostedFields();
+  initHostedFields();
+});
+//--------------------------------
 
 function allowMultiUse(saveTokenEl) {
   return oneClick && $(saveTokenEl).is(':checked');

--- a/src/hipay_enterprise/views/templates/front/payment/ps17/paymentForm-direct_post-17.tpl
+++ b/src/hipay_enterprise/views/templates/front/payment/ps17/paymentForm-direct_post-17.tpl
@@ -62,12 +62,9 @@
 <script>
     document.addEventListener('DOMContentLoaded', setSelectedPaymentMethod, false);
 
-    //Support module One Page Checkout PS - PresTeamShop
+    //Support module One Page Checkout PS - PresTeamShop - v4.1.1 - PrestaShop >= 1.7.6.X
     //--------------------------------
     window.opc_dispatcher.events.addEventListener('payment-getPaymentList-complete', () => {
-        setSelectedPaymentMethod();
-    });
-    $(document).on('opc-load-payment:completed', function() {
         setSelectedPaymentMethod();
     });
     //--------------------------------

--- a/src/hipay_enterprise/views/templates/front/payment/ps17/paymentForm-direct_post-17.tpl
+++ b/src/hipay_enterprise/views/templates/front/payment/ps17/paymentForm-direct_post-17.tpl
@@ -10,6 +10,7 @@
 * @license   https://github.com/hipay/hipay-enterprise-sdk-prestashop/blob/master/LICENSE.md
 *}
 {include file="$hipay_enterprise_tpl_dir/front/partial/js.strings.tpl"}
+
 <form id="tokenizerForm" action="{$action}" enctype="application/x-www-form-urlencoded"
       class="form-horizontal hipay-form-17" method="post"
       name="tokenizerForm" autocomplete="off">
@@ -61,11 +62,21 @@
 <script>
     document.addEventListener('DOMContentLoaded', setSelectedPaymentMethod, false);
 
+    //Support module One Page Checkout PS - PresTeamShop
+    //--------------------------------
+    window.opc_dispatcher.events.addEventListener('payment-getPaymentList-complete', () => {
+        setSelectedPaymentMethod();
+    });
+    $(document).on('opc-load-payment:completed', function() {
+        setSelectedPaymentMethod();
+    });
+    //--------------------------------
+
     var activatedCreditCard = [];
     {foreach $activatedCreditCard as $cc}
     activatedCreditCard.push("{$cc}");
     {/foreach}
-    var lang = "{$language.iso_code}";
+    var lang = "{$LanguagueIsoCode}";
     var activatedCreditCardError = "{l s='This credit card type or the order currency is not supported. Please choose an other payment method.' mod='hipay_enterprise'}";
     var myPaymentMethodSelected = false;
 

--- a/src/hipay_enterprise/views/templates/front/payment/ps17/paymentForm-hosted_fields-17.tpl
+++ b/src/hipay_enterprise/views/templates/front/payment/ps17/paymentForm-hosted_fields-17.tpl
@@ -60,6 +60,16 @@
 <script>
     document.addEventListener('DOMContentLoaded', setSelectedPaymentMethod, false);
 
+    //Support module One Page Checkout PS - PresTeamShop
+    //--------------------------------
+    window.opc_dispatcher.events.addEventListener('payment-getPaymentList-complete', () => {
+        setSelectedPaymentMethod();
+    });
+    $(document).on('opc-load-payment:completed', function() {
+        setSelectedPaymentMethod();
+    });
+    //--------------------------------
+
     {if $confHipay.account.global.sandbox_mode}
     var api_tokenjs_mode = "stage";
     var api_tokenjs_username = "{$confHipay.account.sandbox.api_tokenjs_username_sandbox}";
@@ -82,7 +92,7 @@
     var activatedCreditCardError = "{l s='This credit card type or the order currency is not supported. Please choose an other payment method.' mod='hipay_enterprise'}";
     var oneClick = !!{$confHipay.payment.global.card_token};
 
-    var lang = "{$language.iso_code}";
+    var lang = "{$LanguagueIsoCode}";
 
     var myPaymentMethodSelected = false;
 

--- a/src/hipay_enterprise/views/templates/front/payment/ps17/paymentForm-hosted_fields-17.tpl
+++ b/src/hipay_enterprise/views/templates/front/payment/ps17/paymentForm-hosted_fields-17.tpl
@@ -60,12 +60,9 @@
 <script>
     document.addEventListener('DOMContentLoaded', setSelectedPaymentMethod, false);
 
-    //Support module One Page Checkout PS - PresTeamShop
+    //Support module One Page Checkout PS - PresTeamShop - v4.1.1 - PrestaShop >= 1.7.6.X
     //--------------------------------
     window.opc_dispatcher.events.addEventListener('payment-getPaymentList-complete', () => {
-        setSelectedPaymentMethod();
-    });
-    $(document).on('opc-load-payment:completed', function() {
         setSelectedPaymentMethod();
     });
     //--------------------------------

--- a/src/hipay_enterprise/views/templates/front/payment/ps17/paymentForm-hosted_page-17.tpl
+++ b/src/hipay_enterprise/views/templates/front/payment/ps17/paymentForm-hosted_page-17.tpl
@@ -59,7 +59,7 @@
             var api_tokenjs_password_publickey = "{$confHipay.account.production.api_tokenjs_password_publickey_production}";
             {/if}
 
-            var lang = "{$language.iso_code}";
+            var lang = "{$LanguagueIsoCode}";
 
             var hipay = HiPay({
                 username: api_tokenjs_username,
@@ -97,4 +97,3 @@
         false
     );
 </script>
-


### PR DESCRIPTION
We make compatibility with our new checkout v4.1.1 near launch, only available for PrestaShop greater than or equal to 1.7.6.X.

With the current checkout it is only possible to work with the "Hosted page" operating mode.

New checkout with Hosted fields and Direct Post:
![image](https://user-images.githubusercontent.com/48451631/143651114-c45e1809-0abf-44b7-897a-d8ff53d5e390.png)
![image](https://user-images.githubusercontent.com/48451631/143651600-c2eeb9cf-37e6-449d-becc-e2e96cc1079d.png)

Actual checkout with Hosted page:
![image](https://user-images.githubusercontent.com/48451631/143652547-7d861bf3-9dcf-4218-9cd4-32ea786e4593.png)

