### PR TITLE
Update RequestFormatterAbstract.php

### DIFF
--- a/src/hipay_enterprise/classes/apiFormatter/Request/RequestFormatterAbstract.php
+++ b/src/hipay_enterprise/classes/apiFormatter/Request/RequestFormatterAbstract.php
@@ -231,8 +231,7 @@ abstract class RequestFormatterAbstract extends CommonRequestFormatterAbstract
             $max_length = $this->params["paymentProduct"]['maxLengthDescription'];
         }
         if (Tools::strlen($description) > $max_length) {
-            $offset = ($max_length - 3) - Tools::strlen($description);
-            $description = Tools::substr($description, 0, strrpos($description, ' ', $offset)) . '...';
+            $description = mb_strimwidth($description, 0, $max_length, "...");
         }
 
         return $description;


### PR DESCRIPTION
Fixing bug when triming the description length using '...' - current code is making description to a max size of 256 and produce api error for an over sized description (max 255)