### PR TITLE
Fix upgrade error

### DIFF
--- a/src/hipay_enterprise/upgrade/Upgrade-2.20.0.php
+++ b/src/hipay_enterprise/upgrade/Upgrade-2.20.0.php
@@ -14,6 +14,8 @@ require_once dirname(__FILE__).'/../classes/helper/dbquery/HipayDBSchemaManager.
 
 function upgrade_module_2_20_0($module)
 {
+    $module->registerHook('actionDispatcher');
+
     $log = $module->getLogs();
 
     $sql = ' ALTER TABLE `'._DB_PREFIX_.HipayDBQueryAbstract::HIPAY_NOTIFICATION_TABLE.'`

--- a/src/hipay_enterprise/upgrade/Upgrade-2.7.1.php
+++ b/src/hipay_enterprise/upgrade/Upgrade-2.7.1.php
@@ -11,7 +11,7 @@
  * @license   https://github.com/hipay/hipay-enterprise-sdk-prestashop/blob/master/LICENSE.md
  */
 
-require_once(dirname(__FILE__) . '/../classes/helper/HipayDBQuery.php');
+require_once(dirname(__FILE__) . '/../classes/helper/HipayDBUtils.php');
 
 function upgrade_module_2_7_1($module)
 {

--- a/src/hipay_enterprise/upgrade/Upgrade-2.9.0.php
+++ b/src/hipay_enterprise/upgrade/Upgrade-2.9.0.php
@@ -11,7 +11,7 @@
  * @license   https://github.com/hipay/hipay-enterprise-sdk-prestashop/blob/master/LICENSE.md
  */
 
-require_once(dirname(__FILE__) . '/../classes/helper/HipayDBQuery.php');
+require_once(dirname(__FILE__) . '/../classes/helper/HipayDBUtils.php');
 
 function upgrade_module_2_9_0($module)
 {

--- a/src/hipay_enterprise/upgrade/Upgrade-2.9.4.php
+++ b/src/hipay_enterprise/upgrade/Upgrade-2.9.4.php
@@ -11,7 +11,7 @@
  * @license   https://github.com/hipay/hipay-enterprise-sdk-prestashop/blob/master/LICENSE.md
  */
 
-require_once(dirname(__FILE__) . '/../classes/helper/HipayDBQuery.php');
+require_once(dirname(__FILE__) . '/../classes/helper/HipayDBUtils.php');
 
 function upgrade_module_2_9_4($module)
 {


### PR DESCRIPTION
Since the rename of the HipayDBQuery into HipayDBUtils upgrade trigger a fatal error.

Add missing upgrade for hookActionDispatcher that trigger 

Syntax error in template "file:hipay_enterprise/views/templates/admin/tabs/partials/3ds.forms.partial.tpl" on line 30 "{if $config_hipay.payment.global.3d_secure_rules[0].operator|htmlEntityDecode == ">"}selected="selected"" unknown modifier 'htmlEntityDecode'