### PR TITLE
Fixed division by 0 error in the 'getFeesItem' function

### DIFF
--- a/src/hipay_enterprise/classes/apiFormatter/Cart/CartFormatter.php
+++ b/src/hipay_enterprise/classes/apiFormatter/Cart/CartFormatter.php
@@ -243,7 +243,7 @@ class CartFormatter extends ApiFormatterAbstract
                 $name = 'Multiple carriers';
             }
 
-            $taxRate = round(($totalAmount / $cartSummary['total_shipping_tax_exc'] - 1), 2);
+            $taxRate = $cartSummary['total_shipping_tax_exc'] === 0 ? 0.00 : round(($totalAmount / $cartSummary['total_shipping_tax_exc'] - 1), 2);
             $discount = 0.00;
 
             $item = Item::buildItemTypeFees(


### PR DESCRIPTION
Fr :
Correction de l'erreur de division par 0 dans la fonction 'getFeesItem'
- ajout d'une vérification sur $cartSummary['total_shipping_tax_exc']. Si elle est égale à 0, alors nous assignons "0.00". Sinon, nous effectuons le calcul.

Résultat : Cela évite l'erreur dans le module qui bloquait la création de commande lorsque l'option 'livraison gratuite' était sélectionnée pour un transporteur dans le back office.

En :
Fixed division by 0 error in the 'getFeesItem' function
- added a check on $cartSummary['total_shipping_tax_exc']. If it equals 0, then we assign "0.00". Otherwise, we perform the calculation.

Result: This prevents the error in the module that was blocking the order creation when the 'free shipping' option was selected for a carrier in the back office.