### PR TITLE
Fix module upgrade process

### DIFF
--- a/src/hipay_enterprise/upgrade/Upgrade-2.20.0.php
+++ b/src/hipay_enterprise/upgrade/Upgrade-2.20.0.php
@@ -18,14 +18,6 @@ function upgrade_module_2_20_0($module)
 
     $log = $module->getLogs();
 
-    $sql = ' ALTER TABLE `'._DB_PREFIX_.HipayDBQueryAbstract::HIPAY_NOTIFICATION_TABLE.'`
-        ADD COLUMN `data` TEXT NOT NULL,
-	    ADD INDEX `hipay_notification.update_keys` (`cart_id`, `transaction_ref`, `notification_code`, `status`)';
-
-    if (!Db::getInstance()->execute($sql)) {
-        throw new Exception('Error during SQL request');
-    }
-
     $log->logInfos('Upgrade to 2.20.0');
 
     try {

--- a/src/hipay_enterprise/upgrade/Upgrade-2.21.4.php
+++ b/src/hipay_enterprise/upgrade/Upgrade-2.21.4.php
@@ -30,4 +30,6 @@ function upgrade_module_2_21_4($module)
             throw new Exception('Error during SQL request');
         }
     }
+
+    return true;
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When upgrading the module from a relatively old version (at least prior to 2.20.0), upgrade fails due to problems in upgrade files.
| Type?             | bug fix
| Deprecations?     | no
| How to test?      | Install a 2.17.x version of the module and run the upgrade with the latest release. Check that ugprade succeed.
| Fixed ticket?     | [#87](https://github.com/hipay/hipay-enterprise-sdk-prestashop/issues/87)
| Sponsor company   | Evolutive Group
