### PR TITLE
Fix duplicate cart rules in case of decline payment

### DIFF
--- a/src/hipay_enterprise/classes/helper/HipayHelper.php
+++ b/src/hipay_enterprise/classes/helper/HipayHelper.php
@@ -715,7 +715,6 @@ class HipayHelper
         $duplicationCart = $cart->duplicate();
 
         foreach ($cartRules as $rule) {
-            $duplicationCart['cart']->addCartRule($rule['id_cart_rule']);
             // If the discount is a gift, you don't want to re-apply the discount to add another quantity.
             if (!empty($rule['gift_product']) && (int) $rule['gift_product'] > 0) {
                 $duplicationCart['cart']->updateQty(-1, $rule['gift_product'], $rule['gift_product_attribute']);


### PR DESCRIPTION
### Describe the bug and add screenshots

If a payment is decline (bad credit card), the card is abandonned and a new one is created with a duplication of the cart. 
In this case, the new cart has two cart rules.

### Expected behavior

The cart rule should not be duplicated by the module because the native behaviour already do it. 

### Steps to reproduce

1. Add a product in a cart
2. Add a discount code in the cart
3. Pay with an invalid credit card. Then the return page explain the payment is declined.
4. When you return to the cart, the cart rule is duplicated.

### PrestaShop version(s) where the bug happened

1.7.8.9

### PHP version(s) where the bug happened

7.4